### PR TITLE
BX-68673:  add an async interface to the dotnet binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are breaking changes between the C# Binding and the Dotnet Binding.  In or
 
 Example (C# Binding):
 
-Scene: On-Premise retrieval of entities with full ADM
+Scene: On-Premise retrieval of entities
 
 ``` csharp
   string alturl = "localhost:1234/rest/v1";
@@ -42,7 +42,13 @@ Scene: On-Premise retrieval of entities with full ADM
   // C# sets the url parameter at the api level, affecting all endpoints until reset
   api.SetUrlParameter("output", "rosette");
 
-  string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
+  string entities_text_data = @"The Securities and Exchange Commission today announced 
+  the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief 
+  Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s 
+  Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman 
+  have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible 
+  for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating 
+  with litigators in the SEC’s 11 regional offices around the country.";
 
   EntitiesResponse response = api.Entity(entities_text_data, null, null, null, "social-media");
   foreach (KeyValuePair<string, string> h in response.Headers) {
@@ -58,9 +64,15 @@ Dotnet Binding:
   // The alternate URL is set via a method, rather than through the constructor
   RosetteAPI api = new RosetteAPI(apiKey).UseAlternateURL(altUrl);
 
-  string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
+  string entities_text_data = @"The Securities and Exchange Commission today announced 
+  the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief 
+  Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s 
+  Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman 
+  have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible 
+  for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating 
+  with litigators in the SEC’s 11 regional offices around the country.";
 
-  // Create the endpoint.  In this case we set the genre and want the full ADM.  Note that the url parameters are set for the endpoint only, so other endpoints
+  // Create the endpoint.  Note that the url parameters are set for the endpoint only, so other endpoints
   // are not affected.
   EntitiesEndpoint endpoint = new EntitiesEndpoint(entities_text_data)
     .SetGenre("social-media")
@@ -75,7 +87,7 @@ Dotnet Binding:
   Console.WriteLine(response.ContentAsJson(pretty: true));
 ```
 
-#### Synchronous
+## Synchronous
 ```csharp
 using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
@@ -96,7 +108,7 @@ foreach (KeyValuePair<string, string> h in response.Headers) {
 Console.WriteLine(response.ContentAsJson(pretty: true));
 ```
 
-#### Async (Recommended)
+## Async (Recommended)
 ```csharp
 using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
@@ -104,16 +116,33 @@ using Rosette.Api.Client.Models;
 
 ApiClient api = new("YOUR_API_KEY");
 
-string text = @"The Securities and Exchange Commission today announced the leadership 
-of the agency's trial unit. Bridget Fitzpatrick has been named Chief Litigation Counsel 
-of the SEC.";
+string text_data1 = @"The Securities and Exchange Commission today announced 
+  the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief 
+  Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s 
+  Deputy Chief Litigation Counsel.";
+string text_data2 = @"Since December 2016, Ms. Fitzpatrick and Mr. Gottesman 
+  have served as Co-Acting Chief Litigation Counsel.";
+string text_data3 = @"In that role, they were jointly responsible 
+  for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating 
+  with litigators in the SEC’s 11 regional offices around the country.";
 
-Entities endpoint = new Entities(text).SetGenre("social-media");
+string[] texts = new[] { 
+    text_data1, 
+    text_data2, 
+    text_data3 };
 
-using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-Response response = await endpoint.CallAsync(api, cts.Token);
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)); 
 
-Console.WriteLine(response.ContentAsJson(pretty: true));
+Task<Response>[] tasks = texts
+    .Select(text => new Entities(text).SetGenre("social-media").CallAsync(api, cts.Token))
+    .ToArray();
+
+Response[] responses = await Task.WhenAll(tasks);
+
+foreach (var response in responses) 
+{
+    Console.WriteLine(response.ContentAsJson(pretty: true)); 
+}
 ```
 
 ## Documentation
@@ -153,9 +182,9 @@ View small example programs for each Rosette endpoint
 in the [examples](https://github.com/rosette-api/dotnet/tree/master/examples) directory.
 
 #### Documentation & Support
-- [Binding API](https://rosette-api.github.io/java/)
-- [Analytics Platform API](https://docs.babelstreet.com/API/en/index-en.html)
+- [Binding API](https://rosette-api.github.io/dotnet)
+- [Analytics Platform API](http://documentation.babelstreet.com/analytics)
 - [Binding Release Notes](https://github.com/rosette-api/dotnet/wiki/Release-Notes)
-- [Analytics Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
-- [Support](https://babelstreet.my.site.com/support/s/)
+- [Analytics Platform Release Notes](https://docs.babelstreet.com/r/Hosted-Services-Release-Notes)
+- [Support](https://babelstreet.my.site.com/support/s/contactsupport)
 - [Binding License: Apache 2.0](LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
-# Dotnet Client Binding
+<a href="https://www.babelstreet.com/rosette">
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-dark.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-light.png">
+  <img alt="Babel Street Logo" width="48" height="48">
+</picture>
+</a>
 
-Rosette API Client Library for .Net
+# Analytics by Babel Street
 
-## Summary
+---
 
-This is intended to be a replacement for the C# binding.  Although it is written in C#, it has the following improvements:
+[![NuGet version](https://badge.fury.io/nu/rosette_api.svg)](https://badge.fury.io/nu/rosette_api)
 
-- targets .Net Core 2 rather than Framework
-- updated to handle multi-threaded operations and address some concurrency issues in the old C# binding
-- all new unit tests
-- removal of brittle return types, replaced with IDictionary and JSON so that returned data reflects the latest from the server
+Our product is a full text processing pipeline from data preparation to extracting the most relevant information and
+analysis utilizing precise, focused AI that has built-in human understanding. Text Analytics provides foundational
+linguistic analysis for identifying languages and relating words. The result is enriched and normalized text for
+high-speed search and processing without translation.
 
-## Usage
+Text Analytics extracts events and entities — people, organizations, and places — from unstructured text and adds the
+structure of associating those entities into events that deliver only the necessary information for near real-time
+decision making. Accompanying tools shorten the process of training AI models to recognize domain-specific events.
 
-1. Add the rosette_api package from NuGet: `dotnet add package rosette_api.net` (it's not published yet)
-1. Add `using rosette_api` to your source file
-1. Create a `RosetteAPI` object to manage the HTTP client: `RosetteAPI api = new RosetteAPI(your api key);`
-1. Create an endpoint object: `LanguageEndpoint endpoint = new LanguageEndpoint(content);` Content may be
-    1. A string representing the data to be analyzed
-    1. A filename containing the data to be analyzed
-    1. A valid URL to a web page containing the data to be analyzed
-1. Execute the call: `RosetteResponse response = endpoint.Call(api);`  The response is an object containing `Content`, which is an IDictionary, and `ContentAsJson()`, which is the JSON representation of the `Content`. `Headers` and `StatusCode` are also available.
+The product delivers a multitude of ways to sharpen and expand search results. Semantic similarity expands search
+beyond keywords to words with the same meaning, even in other languages. Sentiment analysis and topic extraction help
+filter results to what’s relevant.
 
-Please refer to the examples and [API documentation](https://rosette-api.github.io/dotnet/) for further details.  Optional parameters to the api and endpoints are accessed via methods.  Required parameters are provided through the constructors.
+## Analytics API Access
+- Analytics Cloud [Sign Up](https://developer.babelstreet.com/signup)
 
 ## Migrating from C# Binding
 
@@ -71,6 +75,46 @@ Dotnet Binding:
   Console.WriteLine(response.ContentAsJson(pretty: true));
 ```
 
+#### Synchronous
+```csharp
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
+
+ApiClient api = new("YOUR_API_KEY");
+
+string text = @"The Securities and Exchange Commission today announced the leadership 
+of the agency's trial unit. Bridget Fitzpatrick has been named Chief Litigation Counsel 
+of the SEC.";
+
+Entities endpoint = new Entities(text).SetGenre("social-media");
+Response response = endpoint.Call(api);
+
+foreach (KeyValuePair<string, string> h in response.Headers) {
+    Console.WriteLine($"{h.Key}:{h.Value}");
+}
+Console.WriteLine(response.ContentAsJson(pretty: true));
+```
+
+#### Async (Recommended)
+```csharp
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
+
+ApiClient api = new("YOUR_API_KEY");
+
+string text = @"The Securities and Exchange Commission today announced the leadership 
+of the agency's trial unit. Bridget Fitzpatrick has been named Chief Litigation Counsel 
+of the SEC.";
+
+Entities endpoint = new Entities(text).SetGenre("social-media");
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+Response response = await endpoint.CallAsync(api, cts.Token);
+
+Console.WriteLine(response.ContentAsJson(pretty: true));
+```
 
 ## Documentation
 
@@ -98,48 +142,20 @@ If you would prefer the manual approach, install dotnet on your computer and ref
 
 ### Building the source
 
-From the root directory of the source tree, `dotnet build`
+From the root directory of the source tree, `dotnet build`.  Note that .NET 10 SDK is a prerequisite for building the source.
 
 ### Running the tests
 
 From the root directory of the source tree, `dotnet test tests/tests.csproj`
 
-### Running the examples against the source code
+#### Examples
+View small example programs for each Rosette endpoint
+in the [examples](https://github.com/rosette-api/dotnet/tree/master/examples) directory.
 
-There does not seem to be a way to compile and run all of the examples without a bit of help. The easiest way to compile and run an example is to create an empty directory using `dotnet new` and update the `.csproj` file to contain:
-
-```csharp
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-      <RestoreSources>$(RestoreSources);../rosette_api/bin/Debug;https://api.nuget.org/v3/index.json</RestoreSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="RosetteAPI.Net" Version="1.9.0" />
-  </ItemGroup>
-
-</Project>
-```
-The `RestoreSources` line should be updated to reference wherever the Debug (or Release) build of the packed source lives (see above).  Also note that the Version may be different from what is shown.
-
-Steps:
-
-1. In an empty directory, `dotnet new console -lang c#`.  This will create several files and an obj directory
-1. Remove `Program.cs`
-1. Edit your `.csproj` to contain the `RestoreSources` line from the above example, making sure to include the path to the `pack` output location, and the `ItemGroup` block
-1. Copy an example file into the directory
-1. `dotnet run ${API_KEY}` where API_KEY is your Rosette API key
-1. To run a different example, delete the one in the directory, copy the new one into the directory and `dotnet run ${API_KEY}`
-
-Developer Note:  If you update the source, you will need to do two things:
-
-1. From the source root, `dotnet pack`
-1. `dotnet nuget locals all --clear` to clear the cached package
-
-
-## Status
-
-In development.  Nothing published to NuGet, yet
+#### Documentation & Support
+- [Binding API](https://rosette-api.github.io/java/)
+- [Analytics Platform API](https://docs.babelstreet.com/API/en/index-en.html)
+- [Binding Release Notes](https://github.com/rosette-api/dotnet/wiki/Release-Notes)
+- [Analytics Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
+- [Support](https://babelstreet.my.site.com/support/s/)
+- [Binding License: Apache 2.0](LICENSE.txt)

--- a/examples/AddressSimilarity.cs
+++ b/examples/AddressSimilarity.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples
 {
@@ -25,7 +25,7 @@ namespace examples
                 var add2 = new FieldedAddressRecord(houseNumber: "1600", road: "Pennsylvania Ave N.W.", city: "Washington", state: "DC", postcode: "20500");
 
 
-                Rosette.Api.Endpoints.AddressSimilarity endpoint = new(add1, add2);
+                Rosette.Api.Client.Endpoints.AddressSimilarity endpoint = new(add1, add2);
 
                 Response response = endpoint.Call(api);
 

--- a/examples/AddressSimilarity.cs
+++ b/examples/AddressSimilarity.cs
@@ -1,60 +1,59 @@
 ﻿using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples
+namespace Rosette.Api.Examples;
+
+class AddressSimilarity
 {
-    class AddressSimilarity
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null)
     {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null)
+        try
         {
-            try
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl))
             {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl))
-                {
-                    api.UseAlternateURL(altUrl);
-                }
-
-                var add1 = new UnfieldedAddressRecord { Address = "160 Pennsylvana Avenue, Washington, D.C., 20500" };
-                var add2 = new FieldedAddressRecord(houseNumber: "1600", road: "Pennsylvania Ave N.W.", city: "Washington", state: "DC", postcode: "20500");
-
-
-                Rosette.Api.Client.Endpoints.AddressSimilarity endpoint = new(add1, add2);
-
-                Response response = endpoint.Call(api);
-
-                //The results of the API call will come back in the form of a Dictionary
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e)
+
+            var add1 = new UnfieldedAddressRecord { Address = "160 Pennsylvana Avenue, Washington, D.C., 20500" };
+            var add2 = new FieldedAddressRecord(houseNumber: "1600", road: "Pennsylvania Ave N.W.", city: "Washington", state: "DC", postcode: "20500");
+
+
+            Rosette.Api.Client.Endpoints.AddressSimilarity endpoint = new(add1, add2);
+
+            Response response = endpoint.Call(api);
+
+            //The results of the API call will come back in the form of a Dictionary
+            foreach (KeyValuePair<string, string> h in response.Headers)
             {
-                Console.WriteLine(e.Message);
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args)
+        catch (Exception e)
         {
-            if (args.Length != 0)
-            {
-                new AddressSimilarity().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else
-            {
-                Console.WriteLine("An API Key is required");
-            }
+            Console.WriteLine(e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args)
+    {
+        if (args.Length != 0)
+        {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else
+        {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Categories.cs
+++ b/examples/Categories.cs
@@ -2,98 +2,98 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 using System.Text;
 
-namespace examples {
-    class Categories
+namespace Rosette.Api.Examples;
+
+class Categories
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            Console.OutputEncoding = Encoding.UTF8;
+
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
+
+            Rosette.Api.Client.Endpoints.Categories endpoint = new(categories_text_data);
+
+            Response response = endpoint.Call(api);
+            //The results of the API call will come back in the form of a Dictionary
+            foreach (KeyValuePair<string, string> h in response.Headers)
+            {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
+            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
+        }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+
+    /// <summary>
+    /// RunEndpointAsync runs the example asynchronously.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static async Task RunEndpointAsync(string apiKey, string? altUrl = null)
     {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                Console.OutputEncoding = Encoding.UTF8;
-                
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
-
-                Rosette.Api.Client.Endpoints.Categories endpoint = new Rosette.Api.Client.Endpoints.Categories(categories_text_data);
-
-                Response response = endpoint.Call(api);
-                //The results of the API call will come back in the form of a Dictionary
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
-            }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
-        }
-
-        /// <summary>
-        /// RunEndpointAsync runs the example asynchronously.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private async Task RunEndpointAsync(string apiKey, string? altUrl = null)
+        try
         {
-            try
+            Console.OutputEncoding = Encoding.UTF8;
+
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl))
             {
-                Console.OutputEncoding = Encoding.UTF8;
-
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl))
-                {
-                    api.UseAlternateURL(altUrl);
-                }
-                string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
-
-                Rosette.Api.Client.Endpoints.Categories endpoint = new Rosette.Api.Client.Endpoints.Categories(categories_text_data);
-
-                // Use async call with optional timeout
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-                Response response = await endpoint.CallAsync(api, cts.Token);
-
-                //The results of the API call will come back in the form of a Dictionary
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+                api.UseAlternateURL(altUrl);
             }
-            catch (OperationCanceledException)
+            string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
+
+            Rosette.Api.Client.Endpoints.Categories endpoint = new(categories_text_data);
+
+            // Use async call with optional timeout
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            Response response = await endpoint.CallAsync(api, cts.Token);
+
+            //The results of the API call will come back in the form of a Dictionary
+            foreach (KeyValuePair<string, string> h in response.Headers)
             {
-                Console.WriteLine("Request was cancelled or timed out");
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e)
-            {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
+        catch (OperationCanceledException)
+        {
+            Console.WriteLine("Request was cancelled or timed out");
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
 
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static async Task Main(string[] args) {
-            if (args.Length != 0) {
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static async Task Main(string[] args) {
+        if (args.Length != 0) {
 
-                Console.WriteLine("\n=== First Call (Async) ===");
-                await new Categories().RunEndpointAsync(args[0], args.Length > 1 ? args[1] : null);
+            Console.WriteLine("\n=== First Call (Async) ===");
+            await RunEndpointAsync(args[0], args.Length > 1 ? args[1] : null);
 
-                Console.WriteLine("\n=== Second Call (Synchronous) ===");
-                new Categories().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+            Console.WriteLine("\n=== Second Call (Synchronous) ===");
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Categories.cs
+++ b/examples/Categories.cs
@@ -1,5 +1,6 @@
 using Rosette.Api;
 using Rosette.Api.Models;
+using System.Text;
 
 namespace examples {
     class Categories
@@ -10,15 +11,17 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
+                Console.OutputEncoding = Encoding.UTF8;
+                
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {
                     api.UseAlternateURL(altUrl);
                 }
                 string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
 
-                Rosette.Api.Endpoints.Categories endpoint = new(categories_text_data);
+                Rosette.Api.Endpoints.Categories endpoint = new Rosette.Api.Endpoints.Categories(categories_text_data);
 
                 Response response = endpoint.Call(api);
                 //The results of the API call will come back in the form of a Dictionary
@@ -29,15 +32,63 @@ namespace examples {
                 Console.WriteLine(response.ContentAsJson(pretty: true));
             }
             catch (Exception e) {
-                Console.WriteLine(e.Message);
+                Console.WriteLine("Exception: " + e.Message);
             }
         }
+
+        /// <summary>
+        /// RunEndpointAsync runs the example asynchronously.  By default the endpoint will be run against the Rosette Cloud Service.
+        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+        /// </summary>
+        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+        /// <param name="altUrl">Optional alternate URL</param>
+        private async Task RunEndpointAsync(string apiKey, string? altUrl = null)
+        {
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+
+                ApiClient api = new ApiClient(apiKey);
+                if (!string.IsNullOrEmpty(altUrl))
+                {
+                    api.UseAlternateURL(altUrl);
+                }
+                string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
+
+                Rosette.Api.Endpoints.Categories endpoint = new Rosette.Api.Endpoints.Categories(categories_text_data);
+
+                // Use async call with optional timeout
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                Response response = await endpoint.CallAsync(api, cts.Token);
+
+                //The results of the API call will come back in the form of a Dictionary
+                foreach (KeyValuePair<string, string> h in response.Headers)
+                {
+                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
+                }
+                Console.WriteLine(response.ContentAsJson(pretty: true));
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("Request was cancelled or timed out");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Exception: " + e.Message);
+            }
+        }
+
         /// <summary>
         /// Main is a simple entrypoint for command line calling of the endpoint examples
         /// </summary>
         /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
+        static async Task Main(string[] args) {
             if (args.Length != 0) {
+
+                Console.WriteLine("\n=== First Call (Async) ===");
+                await new Categories().RunEndpointAsync(args[0], args.Length > 1 ? args[1] : null);
+
+                Console.WriteLine("\n=== Second Call (Synchronous) ===");
                 new Categories().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
             }
             else {

--- a/examples/Categories.cs
+++ b/examples/Categories.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 using System.Text;
 
 namespace examples {
@@ -21,7 +21,7 @@ namespace examples {
                 }
                 string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
 
-                Rosette.Api.Endpoints.Categories endpoint = new Rosette.Api.Endpoints.Categories(categories_text_data);
+                Rosette.Api.Client.Endpoints.Categories endpoint = new Rosette.Api.Client.Endpoints.Categories(categories_text_data);
 
                 Response response = endpoint.Call(api);
                 //The results of the API call will come back in the form of a Dictionary
@@ -55,7 +55,7 @@ namespace examples {
                 }
                 string categories_text_data = @"Sony Pictures is planning to shoot a good portion of the new ""Ghostbusters"" in Boston as well.";
 
-                Rosette.Api.Endpoints.Categories endpoint = new Rosette.Api.Endpoints.Categories(categories_text_data);
+                Rosette.Api.Client.Endpoints.Categories endpoint = new Rosette.Api.Client.Endpoints.Categories(categories_text_data);
 
                 // Use async call with optional timeout
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/examples/ConcurrencyTest.cs
+++ b/examples/ConcurrencyTest.cs
@@ -1,4 +1,4 @@
-using Rosette.Api;
+using Rosette.Api.Client;
 
 namespace examples {
     public class ConcurrencyTest {
@@ -31,7 +31,7 @@ namespace examples {
 
         private static Task runLookup(int taskId, ApiClient api) {
             string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
-            Rosette.Api.Endpoints.Entities endpoint = new(entities_text_data);
+            Rosette.Api.Client.Endpoints.Entities endpoint = new(entities_text_data);
             foreach (int call in Enumerable.Range(0, calls)) {
                 Console.WriteLine("Task ID: {0} call {1}", taskId, call);
                 try {

--- a/examples/ConcurrencyTest.cs
+++ b/examples/ConcurrencyTest.cs
@@ -1,60 +1,60 @@
 using Rosette.Api.Client;
 
-namespace examples {
-    public class ConcurrencyTest {
-        private static int threads = 3;
-        private static int calls = 5;
+namespace Rosette.Api.Examples;
 
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// This particular example runs entities on multiple threads to demonstrate
-        /// concurrency.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private static async Task TestConcurrency(string apiKey, string altUrl) {
-            var tasks = new List<Task>();
-            ApiClient api = new ApiClient(apiKey);
-            if (!string.IsNullOrEmpty(altUrl)) {
-                api.UseAlternateURL(altUrl);
-            }
-            api = api.AssignConcurrentConnections(2); // 2 is the default. Set to the amount allowed by your plan
+public class ConcurrencyTest {
+    private static readonly int threads = 3;
+    private static readonly int calls = 5;
 
-            foreach (int task in Enumerable.Range(0, threads)) {
-                Console.WriteLine("Starting task {0}", task);
-                tasks.Add(Task.Factory.StartNew( () => runLookup(task, api) ));
-            }
-            await Task.WhenAll(tasks);
-            Console.WriteLine("Test complete");
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// This particular example runs entities on multiple threads to demonstrate
+    /// concurrency.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static async Task TestConcurrency(string apiKey, string altUrl) {
+        var tasks = new List<Task>();
+        ApiClient api = new(apiKey);
+        if (!string.IsNullOrEmpty(altUrl)) {
+            api.UseAlternateURL(altUrl);
         }
+        api = api.AssignConcurrentConnections(2); // 2 is the default. Set to the amount allowed by your plan
 
-        private static Task runLookup(int taskId, ApiClient api) {
-            string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
-            Rosette.Api.Client.Endpoints.Entities endpoint = new(entities_text_data);
-            foreach (int call in Enumerable.Range(0, calls)) {
-                Console.WriteLine("Task ID: {0} call {1}", taskId, call);
-                try {
-                    Console.WriteLine(endpoint.Call(api).ContentAsJson(pretty: true));
-                }
-                catch (Exception ex) {
-                    Console.WriteLine(ex);
-                }
-            }
-            return Task.CompletedTask;
+        foreach (int task in Enumerable.Range(0, threads)) {
+            Console.WriteLine("Starting task {0}", task);
+            tasks.Add(Task.Factory.StartNew( () => RunLookup(task, api) ));
         }
+        await Task.WhenAll(tasks);
+        Console.WriteLine("Test complete");
+    }
 
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                TestConcurrency(args[0], args.Length > 1 ? args[1] : null).GetAwaiter().GetResult();
+    private static Task RunLookup(int taskId, ApiClient api) {
+        string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
+        Rosette.Api.Client.Endpoints.Entities endpoint = new(entities_text_data);
+        foreach (int call in Enumerable.Range(0, calls)) {
+            Console.WriteLine("Task ID: {0} call {1}", taskId, call);
+            try {
+                Console.WriteLine(endpoint.Call(api).ContentAsJson(pretty: true));
             }
-            else {
-                Console.WriteLine("An API Key is required");
+            catch (Exception ex) {
+                Console.WriteLine(ex);
             }
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            TestConcurrency(args[0], args.Length > 1 ? args[1] : null).GetAwaiter().GetResult();
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Entities.cs
+++ b/examples/Entities.cs
@@ -1,52 +1,52 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Entities
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
+namespace Rosette.Api.Examples;
 
-                Rosette.Api.Client.Endpoints.Entities endpoint = new Rosette.Api.Client.Endpoints.Entities(entities_text_data).SetGenre("social-media");
-                Response response = endpoint.Call(api);
-
-                // Print out the response headers
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                // Print out the content in JSON format.  The Content property returns an IDictionary.
-                Console.WriteLine(response.ContentAsJson(pretty: true));
-
-                // Retrieve the Entities with full ADM
-                response = endpoint.SetUrlParameter("output", "rosette").Call(api);
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+class Entities
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
+
+            Rosette.Api.Client.Endpoints.Entities endpoint = new Rosette.Api.Client.Endpoints.Entities(entities_text_data).SetGenre("social-media");
+            Response response = endpoint.Call(api);
+
+            // Print out the response headers
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            // Print out the content in JSON format.  The Content property returns an IDictionary.
+            Console.WriteLine(response.ContentAsJson(pretty: true));
+
+            // Retrieve the Entities with full ADM
+            response = endpoint.SetUrlParameter("output", "rosette").Call(api);
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Entities().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Entities.cs
+++ b/examples/Entities.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Entities.cs
+++ b/examples/Entities.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Entities
@@ -18,7 +18,7 @@ namespace examples {
                 }
                 string entities_text_data = @"The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
 
-                Rosette.Api.Endpoints.Entities endpoint = new Rosette.Api.Endpoints.Entities(entities_text_data).SetGenre("social-media");
+                Rosette.Api.Client.Endpoints.Entities endpoint = new Rosette.Api.Client.Endpoints.Entities(entities_text_data).SetGenre("social-media");
                 Response response = endpoint.Call(api);
 
                 // Print out the response headers

--- a/examples/Events.cs
+++ b/examples/Events.cs
@@ -1,48 +1,48 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Events
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string events_text_data = @"Bill Gates went to the store.";
+namespace Rosette.Api.Examples;
 
-                Rosette.Api.Client.Endpoints.Events endpoint = new Rosette.Api.Client.Endpoints.Events(events_text_data);
-                Response response = endpoint.Call(api);
+class Events
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string events_text_data = @"Bill Gates went to the store.";
 
-                // Print out the response headers
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                // Print out the content in JSON format.  The Content property returns an IDictionary.
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            Rosette.Api.Client.Endpoints.Events endpoint = new(events_text_data);
+            Response response = endpoint.Call(api);
+
+            // Print out the response headers
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            // Print out the content in JSON format.  The Content property returns an IDictionary.
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Events().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Events.cs
+++ b/examples/Events.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Events
@@ -18,7 +18,7 @@ namespace examples {
                 }
                 string events_text_data = @"Bill Gates went to the store.";
 
-                Rosette.Api.Endpoints.Events endpoint = new Rosette.Api.Endpoints.Events(events_text_data);
+                Rosette.Api.Client.Endpoints.Events endpoint = new Rosette.Api.Client.Endpoints.Events(events_text_data);
                 Response response = endpoint.Call(api);
 
                 // Print out the response headers

--- a/examples/EventsNegation.cs
+++ b/examples/EventsNegation.cs
@@ -1,49 +1,49 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class EventsNegation
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string events_text_data = @"Bill Gates went to the store.";
+namespace Rosette.Api.Examples;
 
-                Rosette.Api.Client.Endpoints.Events endpoint = new(events_text_data);
-                endpoint.SetOption("negation", "ONLY_POSITIVE");
-                Response response = endpoint.Call(api);
+class EventsNegation
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string events_text_data = @"Bill Gates went to the store.";
 
-                // Print out the response headers
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                // Print out the content in JSON format.  The Content property returns an IDictionary.
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            Rosette.Api.Client.Endpoints.Events endpoint = new(events_text_data);
+            endpoint.SetOption("negation", "ONLY_POSITIVE");
+            Response response = endpoint.Call(api);
+
+            // Print out the response headers
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            // Print out the content in JSON format.  The Content property returns an IDictionary.
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new EventsNegation().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/EventsNegation.cs
+++ b/examples/EventsNegation.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class EventsNegation
@@ -18,7 +18,7 @@ namespace examples {
                 }
                 string events_text_data = @"Bill Gates went to the store.";
 
-                Rosette.Api.Endpoints.Events endpoint = new(events_text_data);
+                Rosette.Api.Client.Endpoints.Events endpoint = new(events_text_data);
                 endpoint.SetOption("negation", "ONLY_POSITIVE");
                 Response response = endpoint.Call(api);
 

--- a/examples/Info.cs
+++ b/examples/Info.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Info.cs
+++ b/examples/Info.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Info
@@ -16,7 +16,7 @@ namespace examples {
                 if (!string.IsNullOrEmpty(altUrl)) {
                     api.UseAlternateURL(altUrl);
                 }
-                Rosette.Api.Endpoints.Info endpoint = new();
+                Rosette.Api.Client.Endpoints.Info endpoint = new();
                 Response response = endpoint.Call(api);
 
                 foreach (KeyValuePair<string, string> h in response.Headers) {

--- a/examples/Info.cs
+++ b/examples/Info.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Info
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                Rosette.Api.Client.Endpoints.Info endpoint = new();
-                Response response = endpoint.Call(api);
+namespace Rosette.Api.Examples;
 
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+class Info
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            Rosette.Api.Client.Endpoints.Info endpoint = new();
+            Response response = endpoint.Call(api);
+
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Info().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Language.cs
+++ b/examples/Language.cs
@@ -10,14 +10,12 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {
                     api.UseAlternateURL(altUrl);
                 }
-                // Example of adding a custom header
-                api = api.AddCustomHeader("X-RosetteAPI-App", "csharp-app");
 
                 string language_data = @"Por favor Señorita, says the man.";
 

--- a/examples/Language.cs
+++ b/examples/Language.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Language
@@ -19,7 +19,7 @@ namespace examples {
 
                 string language_data = @"Por favor Señorita, says the man.";
 
-                Rosette.Api.Endpoints.Language endpoint = new(language_data);
+                Rosette.Api.Client.Endpoints.Language endpoint = new(language_data);
                 //The results of the API call will come back in the form of a Dictionary
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {

--- a/examples/Language.cs
+++ b/examples/Language.cs
@@ -1,47 +1,47 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Language
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
+namespace Rosette.Api.Examples;
 
-                string language_data = @"Por favor Señorita, says the man.";
+class Language
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
 
-                Rosette.Api.Client.Endpoints.Language endpoint = new(language_data);
-                //The results of the API call will come back in the form of a Dictionary
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            string language_data = @"Por favor Señorita, says the man.";
+
+            Rosette.Api.Client.Endpoints.Language endpoint = new(language_data);
+            //The results of the API call will come back in the form of a Dictionary
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Language().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/LanguageMultilingual.cs
+++ b/examples/LanguageMultilingual.cs
@@ -1,47 +1,47 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class LanguageMultilingual
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string language_multilingual_data = @"On Thursday, as protesters gathered in Washington D.C., the United States Federal Communications Commission under Chairman Ajit Pai voted 3-2 to overturn a 2015 decision, commonly called Net Neutrality, that forbade Internet service providers (ISPs) such as Verizon, Comcast, and AT&T from blocking individual websites or charging websites or customers more for faster load times.  Quatre femmes ont été nommées au Conseil de rédaction de la loi du Qatar. Jeudi, le décret royal du Qatar a annoncé que 28 nouveaux membres ont été nommés pour le Conseil de la Choura du pays.  ذكرت مصادر أمنية يونانية، أن 9 موقوفين من منظمة ""د هـ ك ب ج"" الذين كانت قد أوقفتهم الشرطة اليونانية في وقت سابق كانوا يخططون لاغتيال الرئيس التركي رجب طيب أردوغان.";
+namespace Rosette.Api.Examples;
 
-                Rosette.Api.Client.Endpoints.Language endpoint = new Rosette.Api.Client.Endpoints.Language(language_multilingual_data).SetOption("multilingual", true);
+class LanguageMultilingual
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string language_multilingual_data = @"On Thursday, as protesters gathered in Washington D.C., the United States Federal Communications Commission under Chairman Ajit Pai voted 3-2 to overturn a 2015 decision, commonly called Net Neutrality, that forbade Internet service providers (ISPs) such as Verizon, Comcast, and AT&T from blocking individual websites or charging websites or customers more for faster load times.  Quatre femmes ont été nommées au Conseil de rédaction de la loi du Qatar. Jeudi, le décret royal du Qatar a annoncé que 28 nouveaux membres ont été nommés pour le Conseil de la Choura du pays.  ذكرت مصادر أمنية يونانية، أن 9 موقوفين من منظمة ""د هـ ك ب ج"" الذين كانت قد أوقفتهم الشرطة اليونانية في وقت سابق كانوا يخططون لاغتيال الرئيس التركي رجب طيب أردوغان.";
 
-                //The results of the API call will come back in the form of a Dictionary
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            Rosette.Api.Client.Endpoints.Language endpoint = new Rosette.Api.Client.Endpoints.Language(language_multilingual_data).SetOption("multilingual", true);
+
+            //The results of the API call will come back in the form of a Dictionary
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new LanguageMultilingual().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/LanguageMultilingual.cs
+++ b/examples/LanguageMultilingual.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/LanguageMultilingual.cs
+++ b/examples/LanguageMultilingual.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class LanguageMultilingual
@@ -18,7 +18,7 @@ namespace examples {
                 }
                 string language_multilingual_data = @"On Thursday, as protesters gathered in Washington D.C., the United States Federal Communications Commission under Chairman Ajit Pai voted 3-2 to overturn a 2015 decision, commonly called Net Neutrality, that forbade Internet service providers (ISPs) such as Verizon, Comcast, and AT&T from blocking individual websites or charging websites or customers more for faster load times.  Quatre femmes ont été nommées au Conseil de rédaction de la loi du Qatar. Jeudi, le décret royal du Qatar a annoncé que 28 nouveaux membres ont été nommés pour le Conseil de la Choura du pays.  ذكرت مصادر أمنية يونانية، أن 9 موقوفين من منظمة ""د هـ ك ب ج"" الذين كانت قد أوقفتهم الشرطة اليونانية في وقت سابق كانوا يخططون لاغتيال الرئيس التركي رجب طيب أردوغان.";
 
-                Rosette.Api.Endpoints.Language endpoint = new Rosette.Api.Endpoints.Language(language_multilingual_data).SetOption("multilingual", true);
+                Rosette.Api.Client.Endpoints.Language endpoint = new Rosette.Api.Client.Endpoints.Language(language_multilingual_data).SetOption("multilingual", true);
 
                 //The results of the API call will come back in the form of a Dictionary
                 Response response = endpoint.Call(api);

--- a/examples/MorphologyComplete.cs
+++ b/examples/MorphologyComplete.cs
@@ -2,46 +2,46 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class MorphologyComplete
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string morphology_complete_data = @"The quick brown fox jumped over the lazy dog. 👍🏾 Yes he did. B)";
-                //The results of the API call will come back in the form of a Dictionary
-                Morphology endpoint = new(morphology_complete_data, MorphologyFeature.complete);
+namespace Rosette.Api.Examples;
 
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+class MorphologyComplete
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string morphology_complete_data = @"The quick brown fox jumped over the lazy dog. 👍🏾 Yes he did. B)";
+            //The results of the API call will come back in the form of a Dictionary
+            Morphology endpoint = new(morphology_complete_data, MorphologyFeature.complete);
+
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new MorphologyComplete().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/MorphologyComplete.cs
+++ b/examples/MorphologyComplete.cs
@@ -1,6 +1,6 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class MorphologyComplete

--- a/examples/MorphologyComplete.cs
+++ b/examples/MorphologyComplete.cs
@@ -11,7 +11,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/MorphologyCompoundComponents.cs
+++ b/examples/MorphologyCompoundComponents.cs
@@ -1,8 +1,8 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.ApiExamples {
+namespace Rosette.Api.ClientExamples {
     class MorphologyCompoundComponents
     {
         /// <summary>

--- a/examples/MorphologyCompoundComponents.cs
+++ b/examples/MorphologyCompoundComponents.cs
@@ -11,7 +11,7 @@ namespace Rosette.ApiExamples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/MorphologyCompoundComponents.cs
+++ b/examples/MorphologyCompoundComponents.cs
@@ -2,45 +2,45 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.ClientExamples {
-    class MorphologyCompoundComponents
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string morphology_compound_components_data = @"Rechtsschutzversicherungsgesellschaften";
-                //The results of the API call will come back in the form of a Dictionary
-                Morphology endpoint = new(morphology_compound_components_data, MorphologyFeature.compoundComponents);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class MorphologyCompoundComponents
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string morphology_compound_components_data = @"Rechtsschutzversicherungsgesellschaften";
+            //The results of the API call will come back in the form of a Dictionary
+            Morphology endpoint = new(morphology_compound_components_data, MorphologyFeature.compoundComponents);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new MorphologyCompoundComponents().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/MorphologyHanReadings.cs
+++ b/examples/MorphologyHanReadings.cs
@@ -1,6 +1,6 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class MorphologyHanReadings

--- a/examples/MorphologyHanReadings.cs
+++ b/examples/MorphologyHanReadings.cs
@@ -2,45 +2,45 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class MorphologyHanReadings
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try
-            {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string morphology_han_readings_data = @"北京大学生物系主任办公室内部会议";
-                Morphology endpoint = new(morphology_han_readings_data, MorphologyFeature.hanReadings);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class MorphologyHanReadings
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try
+        {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string morphology_han_readings_data = @"北京大学生物系主任办公室内部会议";
+            Morphology endpoint = new(morphology_han_readings_data, MorphologyFeature.hanReadings);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new MorphologyHanReadings().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/MorphologyHanReadings.cs
+++ b/examples/MorphologyHanReadings.cs
@@ -11,7 +11,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try
             {
                 ApiClient api = new ApiClient(apiKey);

--- a/examples/MorphologyLemmas.cs
+++ b/examples/MorphologyLemmas.cs
@@ -2,46 +2,46 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class MorphologyLemmas
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string morphology_lemmas_data = @"The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
-                //The results of the API call will come back in the form of a Dictionary
-                Morphology endpoint = new(morphology_lemmas_data, MorphologyFeature.lemmas);
-                Response response = endpoint.Call(api);
+namespace Rosette.Api.Examples;
 
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+class MorphologyLemmas
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string morphology_lemmas_data = @"The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
+            //The results of the API call will come back in the form of a Dictionary
+            Morphology endpoint = new(morphology_lemmas_data, MorphologyFeature.lemmas);
+            Response response = endpoint.Call(api);
+
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new MorphologyLemmas().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/MorphologyLemmas.cs
+++ b/examples/MorphologyLemmas.cs
@@ -1,6 +1,6 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class MorphologyLemmas

--- a/examples/MorphologyLemmas.cs
+++ b/examples/MorphologyLemmas.cs
@@ -11,7 +11,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/MorphologyPartsOfSpeech.cs
+++ b/examples/MorphologyPartsOfSpeech.cs
@@ -1,6 +1,6 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class MorphologyPartsOfSpeech

--- a/examples/MorphologyPartsOfSpeech.cs
+++ b/examples/MorphologyPartsOfSpeech.cs
@@ -2,44 +2,44 @@ using Rosette.Api.Client;
 using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class MorphologyPartsOfSpeech
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string morphology_parts_of_speech_data = @"The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
-                Morphology endpoint = new(morphology_parts_of_speech_data, MorphologyFeature.partsOfSpeech);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class MorphologyPartsOfSpeech
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string morphology_parts_of_speech_data = @"The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
+            Morphology endpoint = new(morphology_parts_of_speech_data, MorphologyFeature.partsOfSpeech);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new MorphologyPartsOfSpeech().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/MorphologyPartsOfSpeech.cs
+++ b/examples/MorphologyPartsOfSpeech.cs
@@ -11,7 +11,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/NameDeduplication.cs
+++ b/examples/NameDeduplication.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/NameDeduplication.cs
+++ b/examples/NameDeduplication.cs
@@ -1,48 +1,48 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class NameDeduplication
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string name_dedupe_data = @"Alice Terry,Alice Thierry,Betty Grable,Betty Gable,Norma Shearer,Norm Shearer,Brigitte Helm,Bridget Helem,Judy Holliday,Julie Halliday";
+namespace Rosette.Api.Examples;
 
-                List<string> dedupe_names = name_dedupe_data.Split(',').ToList<string>();
-                List<Name> names = dedupe_names.Select(name => new Name(name)).ToList();
+class NameDeduplication
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string name_dedupe_data = @"Alice Terry,Alice Thierry,Betty Grable,Betty Gable,Norma Shearer,Norm Shearer,Brigitte Helm,Bridget Helem,Judy Holliday,Julie Halliday";
 
-                Rosette.Api.Client.Endpoints.NameDeduplication endpoint = new Rosette.Api.Client.Endpoints.NameDeduplication(names).SetThreshold(0.75f);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            List<string> dedupe_names = name_dedupe_data.Split(',').ToList();
+            List<Name> names = dedupe_names.Select(name => new Name(name)).ToList();
+
+            Rosette.Api.Client.Endpoints.NameDeduplication endpoint = new Rosette.Api.Client.Endpoints.NameDeduplication(names).SetThreshold(0.75f);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new NameDeduplication().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/NameDeduplication.cs
+++ b/examples/NameDeduplication.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class NameDeduplication
@@ -21,7 +21,7 @@ namespace examples {
                 List<string> dedupe_names = name_dedupe_data.Split(',').ToList<string>();
                 List<Name> names = dedupe_names.Select(name => new Name(name)).ToList();
 
-                Rosette.Api.Endpoints.NameDeduplication endpoint = new Rosette.Api.Endpoints.NameDeduplication(names).SetThreshold(0.75f);
+                Rosette.Api.Client.Endpoints.NameDeduplication endpoint = new Rosette.Api.Client.Endpoints.NameDeduplication(names).SetThreshold(0.75f);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/NameSimilarity.cs
+++ b/examples/NameSimilarity.cs
@@ -1,48 +1,47 @@
 using Rosette.Api.Client;
-using Rosette.Api.Client.Endpoints;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class NameSimilarity
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
+namespace Rosette.Api.Examples;
 
-                var name1 = new Name("Michael Jackson").SetLanguage("eng").SetEntityType(EntityType.Person);
-                var name2 = new Name("迈克尔·杰克逊").SetEntityType(EntityType.Person);
+class NameSimilarity
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
 
-                Rosette.Api.Client.Endpoints.NameSimilarity endpoint = new(name1, name2);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            var name1 = new Name("Michael Jackson").SetLanguage("eng").SetEntityType(EntityType.Person);
+            var name2 = new Name("迈克尔·杰克逊").SetEntityType(EntityType.Person);
+
+            Rosette.Api.Client.Endpoints.NameSimilarity endpoint = new(name1, name2);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new NameSimilarity().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/NameSimilarity.cs
+++ b/examples/NameSimilarity.cs
@@ -1,6 +1,6 @@
-using Rosette.Api;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class NameSimilarity
@@ -21,7 +21,7 @@ namespace examples {
                 var name1 = new Name("Michael Jackson").SetLanguage("eng").SetEntityType(EntityType.Person);
                 var name2 = new Name("迈克尔·杰克逊").SetEntityType(EntityType.Person);
 
-                Rosette.Api.Endpoints.NameSimilarity endpoint = new(name1, name2);
+                Rosette.Api.Client.Endpoints.NameSimilarity endpoint = new(name1, name2);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/NameSimilarity.cs
+++ b/examples/NameSimilarity.cs
@@ -11,7 +11,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/NameTranslation.cs
+++ b/examples/NameTranslation.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/NameTranslation.cs
+++ b/examples/NameTranslation.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class NameTranslation
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string translated_name_data = @"معمر محمد أبو منيار القذاف";
-                Rosette.Api.Client.Endpoints.NameTranslation endpoint = new(translated_name_data, "eng");
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class NameTranslation
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string translated_name_data = @"معمر محمد أبو منيار القذاف";
+            Rosette.Api.Client.Endpoints.NameTranslation endpoint = new(translated_name_data, "eng");
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new NameTranslation().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/NameTranslation.cs
+++ b/examples/NameTranslation.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class NameTranslation
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string translated_name_data = @"معمر محمد أبو منيار القذاف";
-                Rosette.Api.Endpoints.NameTranslation endpoint = new(translated_name_data, "eng");
+                Rosette.Api.Client.Endpoints.NameTranslation endpoint = new(translated_name_data, "eng");
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/Ping.cs
+++ b/examples/Ping.cs
@@ -1,42 +1,42 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Ping
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                Response response = new Rosette.Api.Client.Endpoints.Ping().Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class Ping
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            Response response = new Rosette.Api.Client.Endpoints.Ping().Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Ping().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Ping.cs
+++ b/examples/Ping.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Ping.cs
+++ b/examples/Ping.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Ping
@@ -16,7 +16,7 @@ namespace examples {
                 if (!string.IsNullOrEmpty(altUrl)) {
                     api.UseAlternateURL(altUrl);
                 }
-                Response response = new Rosette.Api.Endpoints.Ping().Call(api);
+                Response response = new Rosette.Api.Client.Endpoints.Ping().Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
                 }

--- a/examples/RecordSimilarity.cs
+++ b/examples/RecordSimilarity.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples
 {
@@ -86,7 +86,7 @@ namespace examples
                     }
                 };
 
-                Rosette.Api.Endpoints.RecordSimilarity endpoint = new(fields, properties, records);
+                Rosette.Api.Client.Endpoints.RecordSimilarity endpoint = new(fields, properties, records);
                 Response response = endpoint.Call(api);
 
                 // Print out the response headers

--- a/examples/RecordSimilarity.cs
+++ b/examples/RecordSimilarity.cs
@@ -1,121 +1,120 @@
 ﻿using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples
+namespace Rosette.Api.Examples;
+
+class RecordSimilarity
 {
-    class RecordSimilarity
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null)
     {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null)
+        try
         {
-            try
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl))
             {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl))
-                {
-                    api.UseAlternateURL(altUrl);
-                }
+                api.UseAlternateURL(altUrl);
+            }
 
-                // record field names
-                string primaryNameField = "primaryName";
-                string dobField = "dob";
-                string dob2Field = "dob2";
-                string addrField = "addr";
-                string jobField = "jobTitle";
-                string ageField = "age";
-                string retiredField = "isRetired";
-                string dobHyphen = "1993-04-16";
+            // record field names
+            string primaryNameField = "primaryName";
+            string dobField = "dob";
+            string dob2Field = "dob2";
+            string addrField = "addr";
+            string jobField = "jobTitle";
+            string ageField = "age";
+            string retiredField = "isRetired";
+            string dobHyphen = "1993-04-16";
 
-                // Creating the request object
-                Dictionary<string, RecordSimilarityFieldInfo> fields = new Dictionary<string, RecordSimilarityFieldInfo>
-                {
-                    { primaryNameField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniName, Weight = 0.5 } },
-                    { dobField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniDate, Weight = 0.2 } },
-                    { dob2Field, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniDate, Weight = 0.1 } },
-                    { addrField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniAddress, Weight = 0.5 } },
-                    { jobField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniString, Weight = 0.2 } },
-                    { ageField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniNumber, Weight = 0.4 } },
-                    { retiredField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniBoolean, Weight = 0.05 } }
-                };
+            // Creating the request object
+            Dictionary<string, RecordSimilarityFieldInfo> fields = new()
+            {
+                { primaryNameField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniName, Weight = 0.5 } },
+                { dobField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniDate, Weight = 0.2 } },
+                { dob2Field, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniDate, Weight = 0.1 } },
+                { addrField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniAddress, Weight = 0.5 } },
+                { jobField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniString, Weight = 0.2 } },
+                { ageField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniNumber, Weight = 0.4 } },
+                { retiredField, new RecordSimilarityFieldInfo { Type = RecordFieldType.RniBoolean, Weight = 0.05 } }
+            };
 
-                RecordSimilarityProperties properties = new RecordSimilarityProperties { Threshold = 0.7, IncludeExplainInfo = true };
+            RecordSimilarityProperties properties = new() { Threshold = 0.7, IncludeExplainInfo = true };
 
-                RecordSimilarityRecords records = new RecordSimilarityRecords
-                {
-                    Left = new List<Dictionary<string, RecordSimilarityField>>
+            RecordSimilarityRecords records = new()
+            {
+                Left =
+                [
+                    new Dictionary<string, RecordSimilarityField>
                     {
-                        new Dictionary<string, RecordSimilarityField>
-                        {
-                            { primaryNameField, new FieldedNameRecord { Text = "Ethan R", Language = "eng", LanguageOfOrigin = "eng", Script = "Latn", EntityType = "PERSON"} },
-                            { dobField, new UnfieldedDateRecord { Date = dobHyphen} },
-                            { dob2Field, new FieldedDateRecord { Date = "04161993", Format = "MMddyyyy"} },
-                            { addrField, new UnfieldedAddressRecord { Address = "123 Roadlane Ave"} },
-                            { jobField, new StringRecord { Text = "software engineer"} }
-                        },
-                        new Dictionary<string, RecordSimilarityField>
-                        {
-                            { primaryNameField, new FieldedNameRecord { Text = "Evan R"} },
-                            { dobField, new FieldedDateRecord { Date = dobHyphen} },
-                            { ageField, new NumberRecord { Number = 47.344 } },
-                            { retiredField, new BooleanRecord { Boolean = false } }
-                        }
+                        { primaryNameField, new FieldedNameRecord { Text = "Ethan R", Language = "eng", LanguageOfOrigin = "eng", Script = "Latn", EntityType = "PERSON"} },
+                        { dobField, new UnfieldedDateRecord { Date = dobHyphen} },
+                        { dob2Field, new FieldedDateRecord { Date = "04161993", Format = "MMddyyyy"} },
+                        { addrField, new UnfieldedAddressRecord { Address = "123 Roadlane Ave"} },
+                        { jobField, new StringRecord { Text = "software engineer"} }
                     },
-                    Right = new List<Dictionary<string, RecordSimilarityField>>
+                    new Dictionary<string, RecordSimilarityField>
                     {
-                        new Dictionary<string, RecordSimilarityField>
-                        {
-                            { primaryNameField, new FieldedNameRecord { Text = "Seth R", Language = "eng"} },
-                            { dobField, new FieldedDateRecord { Date = dobHyphen} },
-                            { jobField, new StringRecord { Text = "manager"} },
-                            { retiredField, new BooleanRecord { Boolean = true } }
-                        },
-                        new Dictionary<string, RecordSimilarityField>
-                        {
-                            { primaryNameField, new UnfieldedNameRecord { Text = "Ivan R"} },
-                            { dobField, new FieldedDateRecord { Date = dobHyphen} },
-                            { dob2Field, new FieldedDateRecord { Date = "1993/04/16"} },
-                            { addrField, new FieldedAddressRecord { HouseNumber = "123", Road = "Roadlane Ave"} },
-                            { ageField, new NumberRecord { Number = 72 } },
-                            { retiredField, new BooleanRecord { Boolean = true } }
-                        }
+                        { primaryNameField, new FieldedNameRecord { Text = "Evan R"} },
+                        { dobField, new FieldedDateRecord { Date = dobHyphen} },
+                        { ageField, new NumberRecord { Number = 47.344 } },
+                        { retiredField, new BooleanRecord { Boolean = false } }
                     }
-                };
+                ],
+                Right =
+                [
+                    new Dictionary<string, RecordSimilarityField>
+                    {
+                        { primaryNameField, new FieldedNameRecord { Text = "Seth R", Language = "eng"} },
+                        { dobField, new FieldedDateRecord { Date = dobHyphen} },
+                        { jobField, new StringRecord { Text = "manager"} },
+                        { retiredField, new BooleanRecord { Boolean = true } }
+                    },
+                    new Dictionary<string, RecordSimilarityField>
+                    {
+                        { primaryNameField, new UnfieldedNameRecord { Text = "Ivan R"} },
+                        { dobField, new FieldedDateRecord { Date = dobHyphen} },
+                        { dob2Field, new FieldedDateRecord { Date = "1993/04/16"} },
+                        { addrField, new FieldedAddressRecord { HouseNumber = "123", Road = "Roadlane Ave"} },
+                        { ageField, new NumberRecord { Number = 72 } },
+                        { retiredField, new BooleanRecord { Boolean = true } }
+                    }
+                ]
+            };
 
-                Rosette.Api.Client.Endpoints.RecordSimilarity endpoint = new(fields, properties, records);
-                Response response = endpoint.Call(api);
+            Rosette.Api.Client.Endpoints.RecordSimilarity endpoint = new(fields, properties, records);
+            Response response = endpoint.Call(api);
 
-                // Print out the response headers
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                // Print out the content in JSON format.  The Content property returns an IDictionary.
-                Console.WriteLine(response.ContentAsJson(pretty: true));
-            }
-            catch (Exception e)
+            // Print out the response headers
+            foreach (KeyValuePair<string, string> h in response.Headers)
             {
-                Console.WriteLine("Exception: " + e.Message);
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            // Print out the content in JSON format.  The Content property returns an IDictionary.
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args)
+        catch (Exception e)
         {
-            if (args.Length != 0)
-            {
-                new RecordSimilarity().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else
-            {
-                Console.WriteLine("An API Key is required");
-            }
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args)
+    {
+        if (args.Length != 0)
+        {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else
+        {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Relationships.cs
+++ b/examples/Relationships.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Relationships.cs
+++ b/examples/Relationships.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Relationships
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string relationships_text_data = @"FLIR Systems is headquartered in Oregon and produces thermal imaging, night vision, and infrared cameras and sensor systems.  According to the SEC’s order instituting a settled administrative proceeding, FLIR entered into a multi-million dollar contract to provide thermal binoculars to the Saudi government in November 2008.  Timms and Ramahi were the primary sales employees responsible for the contract, and also were involved in negotiations to sell FLIR’s security cameras to the same government officials.  At the time, Timms was the head of FLIR’s Middle East office in Dubai.";
-                Rosette.Api.Client.Endpoints.Relationships endpoint = new(relationships_text_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class Relationships
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string relationships_text_data = @"FLIR Systems is headquartered in Oregon and produces thermal imaging, night vision, and infrared cameras and sensor systems.  According to the SEC’s order instituting a settled administrative proceeding, FLIR entered into a multi-million dollar contract to provide thermal binoculars to the Saudi government in November 2008.  Timms and Ramahi were the primary sales employees responsible for the contract, and also were involved in negotiations to sell FLIR’s security cameras to the same government officials.  At the time, Timms was the head of FLIR’s Middle East office in Dubai.";
+            Rosette.Api.Client.Endpoints.Relationships endpoint = new(relationships_text_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Relationships().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Relationships.cs
+++ b/examples/Relationships.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Relationships
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string relationships_text_data = @"FLIR Systems is headquartered in Oregon and produces thermal imaging, night vision, and infrared cameras and sensor systems.  According to the SEC’s order instituting a settled administrative proceeding, FLIR entered into a multi-million dollar contract to provide thermal binoculars to the Saudi government in November 2008.  Timms and Ramahi were the primary sales employees responsible for the contract, and also were involved in negotiations to sell FLIR’s security cameras to the same government officials.  At the time, Timms was the head of FLIR’s Middle East office in Dubai.";
-                Rosette.Api.Endpoints.Relationships endpoint = new(relationships_text_data);
+                Rosette.Api.Client.Endpoints.Relationships endpoint = new(relationships_text_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/SemanticsVector.cs
+++ b/examples/SemanticsVector.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples
 {
@@ -21,7 +21,7 @@ namespace examples
                     api.UseAlternateURL(altUrl);
                 }
                 string semantic_vectors_data = @"Cambridge, Massachusetts";
-                Rosette.Api.Endpoints.SemanticsVector endpoint = new(semantic_vectors_data);
+                Rosette.Api.Client.Endpoints.SemanticsVector endpoint = new(semantic_vectors_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers)
                 {

--- a/examples/SemanticsVector.cs
+++ b/examples/SemanticsVector.cs
@@ -1,53 +1,52 @@
 ﻿using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples
+namespace Rosette.Api.Examples;
+
+class SemanticsVector
 {
-    class SemanticsVector
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null)
     {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null)
+        try
         {
-            try
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl))
             {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl))
-                {
-                    api.UseAlternateURL(altUrl);
-                }
-                string semantic_vectors_data = @"Cambridge, Massachusetts";
-                Rosette.Api.Client.Endpoints.SemanticsVector endpoint = new(semantic_vectors_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e)
+            string semantic_vectors_data = @"Cambridge, Massachusetts";
+            Rosette.Api.Client.Endpoints.SemanticsVector endpoint = new(semantic_vectors_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers)
             {
-                Console.WriteLine("Exception: " + e.Message);
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args)
+        catch (Exception e)
         {
-            if (args.Length != 0)
-            {
-                new SemanticsVector().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else
-            {
-                Console.WriteLine("An API Key is required");
-            }
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args)
+    {
+        if (args.Length != 0)
+        {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else
+        {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Sentences.cs
+++ b/examples/Sentences.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Sentences
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string sentences_data = @"This land is your land. This land is my land, from California to the New York island; from the red wood forest to the Gulf Stream waters. This land was made for you and Me. As I was walking that ribbon of highway, I saw above me that endless skyway: I saw below me that golden valley: This land was made for you and me.";
-                Rosette.Api.Endpoints.Sentences endpoint = new(sentences_data);
+                Rosette.Api.Client.Endpoints.Sentences endpoint = new(sentences_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/Sentences.cs
+++ b/examples/Sentences.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Sentences.cs
+++ b/examples/Sentences.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Sentences
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string sentences_data = @"This land is your land. This land is my land, from California to the New York island; from the red wood forest to the Gulf Stream waters. This land was made for you and Me. As I was walking that ribbon of highway, I saw above me that endless skyway: I saw below me that golden valley: This land was made for you and me.";
-                Rosette.Api.Client.Endpoints.Sentences endpoint = new(sentences_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class Sentences
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string sentences_data = @"This land is your land. This land is my land, from California to the New York island; from the red wood forest to the Gulf Stream waters. This land was made for you and Me. As I was walking that ribbon of highway, I saw above me that endless skyway: I saw below me that golden valley: This land was made for you and me.";
+            Rosette.Api.Client.Endpoints.Sentences endpoint = new(sentences_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Sentences().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Sentiment.cs
+++ b/examples/Sentiment.cs
@@ -1,59 +1,59 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Sentiment
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                // Create a temporary file to demonstrate multi-part file upload of data
-                var newFile = Path.GetTempFileName();
-                StreamWriter sw = new StreamWriter(newFile);
-                string sentiment_file_data = @"<html><head><title>New Ghostbusters Film</title></head><body><p>Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t be more pleased with the new all-female Ghostbusters cast, telling The Hollywood Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these most magnificent women in comedy.”</p></body></html>";
-                sw.WriteLine(sentiment_file_data);
-                sw.Flush();
-                sw.Close();
+namespace Rosette.Api.Examples;
 
-                using (FileStream fs = File.OpenRead(newFile)) {
-                    Rosette.Api.Client.Endpoints.Sentiment endpoint = new Rosette.Api.Client.Endpoints.Sentiment(fs)
-                        .SetFileContentType(@"application/octet-stream")
-                        .SetLanguage("eng");
-                    Response response = endpoint.Call(api);
-                    foreach (KeyValuePair<string, string> h in response.Headers) {
-                        Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                    }
-                    Console.WriteLine(response.ContentAsJson(pretty: true));
-                }
-
-                if (File.Exists(newFile)) {
-                    File.Delete(newFile);
-                }
+class Sentiment
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            // Create a temporary file to demonstrate multi-part file upload of data
+            var newFile = Path.GetTempFileName();
+            StreamWriter sw = new(newFile);
+            string sentiment_file_data = @"<html><head><title>New Ghostbusters Film</title></head><body><p>Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t be more pleased with the new all-female Ghostbusters cast, telling The Hollywood Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these most magnificent women in comedy.”</p></body></html>";
+            sw.WriteLine(sentiment_file_data);
+            sw.Flush();
+            sw.Close();
+
+            using (FileStream fs = File.OpenRead(newFile)) {
+                Rosette.Api.Client.Endpoints.Sentiment endpoint = new Rosette.Api.Client.Endpoints.Sentiment(fs)
+                    .SetFileContentType(@"application/octet-stream")
+                    .SetLanguage("eng");
+                Response response = endpoint.Call(api);
+                foreach (KeyValuePair<string, string> h in response.Headers) {
+                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
+                }
+                Console.WriteLine(response.ContentAsJson(pretty: true));
+            }
+
+            if (File.Exists(newFile)) {
+                File.Delete(newFile);
             }
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Sentiment().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Sentiment.cs
+++ b/examples/Sentiment.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Sentiment
@@ -25,7 +25,7 @@ namespace examples {
                 sw.Close();
 
                 using (FileStream fs = File.OpenRead(newFile)) {
-                    Rosette.Api.Endpoints.Sentiment endpoint = new Rosette.Api.Endpoints.Sentiment(fs)
+                    Rosette.Api.Client.Endpoints.Sentiment endpoint = new Rosette.Api.Client.Endpoints.Sentiment(fs)
                         .SetFileContentType(@"application/octet-stream")
                         .SetLanguage("eng");
                     Response response = endpoint.Call(api);

--- a/examples/Sentiment.cs
+++ b/examples/Sentiment.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/SimilarTerms.cs
+++ b/examples/SimilarTerms.cs
@@ -1,60 +1,59 @@
 ﻿using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples
+namespace Rosette.Api.Examples;
+
+class SimilarTerms
 {
-    class SimilarTerms
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null)
     {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null)
+        try
         {
-            try
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl))
             {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl))
-                {
-                    api.UseAlternateURL(altUrl);
-                }
-
-                var similar_terms_data = "spy";
-                var resultLanguages = new List<string>() { "spa", "deu", "jpn" };
-
-                Rosette.Api.Client.Endpoints.SimilarTerms endpoint = new(similar_terms_data);
-                endpoint.SetOption("resultLanguages", resultLanguages);
-                Response response = endpoint.Call(api);
-
-                // Print out the response headers
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                // Print out the content in JSON format.  The Content property returns an IDictionary.
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e)
+
+            var similar_terms_data = "spy";
+            var resultLanguages = new List<string>() { "spa", "deu", "jpn" };
+
+            Rosette.Api.Client.Endpoints.SimilarTerms endpoint = new(similar_terms_data);
+            endpoint.SetOption("resultLanguages", resultLanguages);
+            Response response = endpoint.Call(api);
+
+            // Print out the response headers
+            foreach (KeyValuePair<string, string> h in response.Headers)
             {
-                Console.WriteLine("Exception: " + e.Message);
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            // Print out the content in JSON format.  The Content property returns an IDictionary.
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args)
+        catch (Exception e)
         {
-            if (args.Length != 0)
-            {
-                new SimilarTerms().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else
-            {
-                Console.WriteLine("An API Key is required");
-            }
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args)
+    {
+        if (args.Length != 0)
+        {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else
+        {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/SimilarTerms.cs
+++ b/examples/SimilarTerms.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples
 {
@@ -24,7 +24,7 @@ namespace examples
                 var similar_terms_data = "spy";
                 var resultLanguages = new List<string>() { "spa", "deu", "jpn" };
 
-                Rosette.Api.Endpoints.SimilarTerms endpoint = new(similar_terms_data);
+                Rosette.Api.Client.Endpoints.SimilarTerms endpoint = new(similar_terms_data);
                 endpoint.SetOption("resultLanguages", resultLanguages);
                 Response response = endpoint.Call(api);
 

--- a/examples/SyntaxDependencies.cs
+++ b/examples/SyntaxDependencies.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class SyntaxDependencies
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string syntax_dependencies_data = "Yoshinori Ohsumi, a Japanese cell biologist, was awarded the Nobel Prize in Physiology or Medicine on Monday.";
-                Rosette.Api.Endpoints.SyntaxDependencies endpoint = new(syntax_dependencies_data);
+                Rosette.Api.Client.Endpoints.SyntaxDependencies endpoint = new(syntax_dependencies_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/SyntaxDependencies.cs
+++ b/examples/SyntaxDependencies.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/SyntaxDependencies.cs
+++ b/examples/SyntaxDependencies.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class SyntaxDependencies
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string syntax_dependencies_data = "Yoshinori Ohsumi, a Japanese cell biologist, was awarded the Nobel Prize in Physiology or Medicine on Monday.";
-                Rosette.Api.Client.Endpoints.SyntaxDependencies endpoint = new(syntax_dependencies_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class SyntaxDependencies
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string syntax_dependencies_data = "Yoshinori Ohsumi, a Japanese cell biologist, was awarded the Nobel Prize in Physiology or Medicine on Monday.";
+            Rosette.Api.Client.Endpoints.SyntaxDependencies endpoint = new(syntax_dependencies_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new SyntaxDependencies().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/TextEmbedding.cs
+++ b/examples/TextEmbedding.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/TextEmbedding.cs
+++ b/examples/TextEmbedding.cs
@@ -1,46 +1,46 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class TextEmbedding
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string embedding_data = @"Cambridge, Massachusetts";
-                Rosette.Api.Client.Endpoints.TextEmbedding endpoint = new(embedding_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers)
-                {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
+namespace Rosette.Api.Examples;
 
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+class TextEmbedding
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine(e.Message);
+            string embedding_data = @"Cambridge, Massachusetts";
+            Rosette.Api.Client.Endpoints.TextEmbedding endpoint = new(embedding_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers)
+            {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new TextEmbedding().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine(e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/TextEmbedding.cs
+++ b/examples/TextEmbedding.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class TextEmbedding
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string embedding_data = @"Cambridge, Massachusetts";
-                Rosette.Api.Endpoints.TextEmbedding endpoint = new(embedding_data);
+                Rosette.Api.Client.Endpoints.TextEmbedding endpoint = new(embedding_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers)
                 {

--- a/examples/Tokens.cs
+++ b/examples/Tokens.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Tokens
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string tokens_data = @"北京大学生物系主任办公室内部会议";
-                Rosette.Api.Client.Endpoints.Tokens endpoint = new(tokens_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class Tokens
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string tokens_data = @"北京大学生物系主任办公室内部会议";
+            Rosette.Api.Client.Endpoints.Tokens endpoint = new(tokens_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Tokens().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Tokens.cs
+++ b/examples/Tokens.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Tokens.cs
+++ b/examples/Tokens.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Tokens
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string tokens_data = @"北京大学生物系主任办公室内部会议";
-                Rosette.Api.Endpoints.Tokens endpoint = new(tokens_data);
+                Rosette.Api.Client.Endpoints.Tokens endpoint = new(tokens_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/Topics.cs
+++ b/examples/Topics.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/examples/Topics.cs
+++ b/examples/Topics.cs
@@ -1,44 +1,44 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Topics 
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string topics_data = @"Lily Collins is in talks to join Nicholas Hoult in Chernin Entertainment and Fox Searchlight's J.R.R. Tolkien biopic Tolkien. Anthony Boyle, known for playing Scorpius Malfoy in the British play Harry Potter and the Cursed Child, also has signed on for the film centered on the famed author. In Tolkien, Hoult will play the author of the Hobbit and Lord of the Rings book series that were later adapted into two Hollywood trilogies from Peter Jackson. Dome Karukoski is directing the project.";
-                Rosette.Api.Client.Endpoints.Topics endpoint = new(topics_data);
-                Response response = endpoint.Call(api);
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+namespace Rosette.Api.Examples;
+
+class Topics 
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
+            string topics_data = @"Lily Collins is in talks to join Nicholas Hoult in Chernin Entertainment and Fox Searchlight's J.R.R. Tolkien biopic Tolkien. Anthony Boyle, known for playing Scorpius Malfoy in the British play Harry Potter and the Cursed Child, also has signed on for the film centered on the famed author. In Tolkien, Hoult will play the author of the Hobbit and Lord of the Rings book series that were later adapted into two Hollywood trilogies from Peter Jackson. Dome Karukoski is directing the project.";
+            Rosette.Api.Client.Endpoints.Topics endpoint = new(topics_data);
+            Response response = endpoint.Call(api);
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Topics().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Topics.cs
+++ b/examples/Topics.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Topics 
@@ -17,7 +17,7 @@ namespace examples {
                     api.UseAlternateURL(altUrl);
                 }
                 string topics_data = @"Lily Collins is in talks to join Nicholas Hoult in Chernin Entertainment and Fox Searchlight's J.R.R. Tolkien biopic Tolkien. Anthony Boyle, known for playing Scorpius Malfoy in the British play Harry Potter and the Cursed Child, also has signed on for the film centered on the famed author. In Tolkien, Hoult will play the author of the Hobbit and Lord of the Rings book series that were later adapted into two Hollywood trilogies from Peter Jackson. Dome Karukoski is directing the project.";
-                Rosette.Api.Endpoints.Topics endpoint = new(topics_data);
+                Rosette.Api.Client.Endpoints.Topics endpoint = new(topics_data);
                 Response response = endpoint.Call(api);
                 foreach (KeyValuePair<string, string> h in response.Headers) {
                     Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));

--- a/examples/Transliteration.cs
+++ b/examples/Transliteration.cs
@@ -1,5 +1,5 @@
-using Rosette.Api;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Models;
 
 namespace examples {
     class Transliteration
@@ -18,7 +18,7 @@ namespace examples {
                 }
                 string transliteration_data = "ana r2ye7 el gam3a el sa3a 3 el 3asr";
 
-                Rosette.Api.Endpoints.Transliteration endpoint = new Rosette.Api.Endpoints.Transliteration(transliteration_data).SetLanguage("ara");
+                Rosette.Api.Client.Endpoints.Transliteration endpoint = new Rosette.Api.Client.Endpoints.Transliteration(transliteration_data).SetLanguage("ara");
                 Response response = endpoint.Call(api);
 
                 foreach (KeyValuePair<string, string> h in response.Headers) {

--- a/examples/Transliteration.cs
+++ b/examples/Transliteration.cs
@@ -1,46 +1,46 @@
 using Rosette.Api.Client;
 using Rosette.Api.Client.Models;
 
-namespace examples {
-    class Transliteration
-    {
-        /// <summary>
-        /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
-        /// An optional alternate URL may be provided, i.e. for an on-premise solution.
-        /// </summary>
-        /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
-        /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl = null) {
-            try {
-                ApiClient api = new ApiClient(apiKey);
-                if (!string.IsNullOrEmpty(altUrl)) {
-                    api.UseAlternateURL(altUrl);
-                }
-                string transliteration_data = "ana r2ye7 el gam3a el sa3a 3 el 3asr";
+namespace Rosette.Api.Examples;
 
-                Rosette.Api.Client.Endpoints.Transliteration endpoint = new Rosette.Api.Client.Endpoints.Transliteration(transliteration_data).SetLanguage("ara");
-                Response response = endpoint.Call(api);
+class Transliteration
+{
+    /// <summary>
+    /// RunEndpoint runs the example.  By default the endpoint will be run against the Rosette Cloud Service.
+    /// An optional alternate URL may be provided, i.e. for an on-premise solution.
+    /// </summary>
+    /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
+    /// <param name="altUrl">Optional alternate URL</param>
+    private static void RunEndpoint(string apiKey, string? altUrl = null) {
+        try {
+            ApiClient api = new(apiKey);
+            if (!string.IsNullOrEmpty(altUrl)) {
+                api.UseAlternateURL(altUrl);
+            }
+            string transliteration_data = "ana r2ye7 el gam3a el sa3a 3 el 3asr";
 
-                foreach (KeyValuePair<string, string> h in response.Headers) {
-                    Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
-                }
-                Console.WriteLine(response.ContentAsJson(pretty: true));
+            Rosette.Api.Client.Endpoints.Transliteration endpoint = new Rosette.Api.Client.Endpoints.Transliteration(transliteration_data).SetLanguage("ara");
+            Response response = endpoint.Call(api);
+
+            foreach (KeyValuePair<string, string> h in response.Headers) {
+                Console.WriteLine(string.Format("{0}:{1}", h.Key, h.Value));
             }
-            catch (Exception e) {
-                Console.WriteLine("Exception: " + e.Message);
-            }
+            Console.WriteLine(response.ContentAsJson(pretty: true));
         }
-        /// <summary>
-        /// Main is a simple entrypoint for command line calling of the endpoint examples
-        /// </summary>
-        /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
-        static void Main(string[] args) {
-            if (args.Length != 0) {
-                new Transliteration().RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
-            }
-            else {
-                Console.WriteLine("An API Key is required");
-            }
+        catch (Exception e) {
+            Console.WriteLine("Exception: " + e.Message);
+        }
+    }
+    /// <summary>
+    /// Main is a simple entrypoint for command line calling of the endpoint examples
+    /// </summary>
+    /// <param name="args">Command line args, expects API Key, (optional) alt URL</param>
+    static void Main(string[] args) {
+        if (args.Length != 0) {
+            RunEndpoint(args[0], args.Length > 1 ? args[1] : null);
+        }
+        else {
+            Console.WriteLine("An API Key is required");
         }
     }
 }

--- a/examples/Transliteration.cs
+++ b/examples/Transliteration.cs
@@ -10,7 +10,7 @@ namespace examples {
         /// </summary>
         /// <param name="apiKey">Required api key (obtained from Basis Technology)</param>
         /// <param name="altUrl">Optional alternate URL</param>
-        private void RunEndpoint(string apiKey, string? altUrl =null) {
+        private void RunEndpoint(string apiKey, string? altUrl = null) {
             try {
                 ApiClient api = new ApiClient(apiKey);
                 if (!string.IsNullOrEmpty(altUrl)) {

--- a/rosette_api/ApiClient.cs
+++ b/rosette_api/ApiClient.cs
@@ -19,7 +19,7 @@ public class ApiClient : IDisposable
 
     /// <summary>
     /// URI is the uri of the Rosette API server.
-    /// Default: https://api.rosette.com/rest/v1/
+    /// Default: https://analytics.babelstreet.com/rest/v1/
     /// </summary>
     public string URI { get; private set; }
 
@@ -54,7 +54,7 @@ public class ApiClient : IDisposable
     public ApiClient(string apiKey) {
         ArgumentNullException.ThrowIfNull(apiKey);
         APIKey = apiKey;
-        URI = "https://api.rosette.com/rest/v1/";
+        URI = "https://analytics.babelstreet.com/rest/v1/";
         Client = null;
         ConcurrentConnections = 2;
         Timeout = 300;

--- a/rosette_api/ApiClient.cs
+++ b/rosette_api/ApiClient.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
 
-namespace Rosette.Api;
+namespace Rosette.Api.Client;
 
 public class ApiClient : IDisposable
 {

--- a/rosette_api/Endpoints/AddressSimilarity.cs
+++ b/rosette_api/Endpoints/AddressSimilarity.cs
@@ -1,7 +1,7 @@
-using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class AddressSimilarity : EndpointBase<AddressSimilarity>
     {

--- a/rosette_api/Endpoints/AddressSimilarity.cs
+++ b/rosette_api/Endpoints/AddressSimilarity.cs
@@ -18,7 +18,12 @@ namespace Rosette.Api.Endpoints
             Params["address2"] = address2;
         }
 
-        public Response Call(ApiClient api)
+        public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+        {
+            return Funcs.PostCallAsync(api, cancellationToken);
+        }
+
+        public new Response Call(ApiClient api)
         {
             return Funcs.PostCall(api);
         }

--- a/rosette_api/Endpoints/Categories.cs
+++ b/rosette_api/Endpoints/Categories.cs
@@ -8,7 +8,6 @@ public class Categories : ContentEndpointBase<Categories>
     /// CategoriesEndpoint returns the categories extracted from the endpoint
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Categories(object content) : base("categories", content)
-    {
-    }
+    public Categories(object content) : base("categories", content) { }
 }
+

--- a/rosette_api/Endpoints/Categories.cs
+++ b/rosette_api/Endpoints/Categories.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Categories : ContentEndpointBase<Categories>
 {

--- a/rosette_api/Endpoints/Core/ContentEndpointBase.cs
+++ b/rosette_api/Endpoints/Core/ContentEndpointBase.cs
@@ -94,23 +94,23 @@ public abstract class ContentEndpointBase<T> : EndpointBase<T> where T : Content
     public string Filename => Funcs.Filename;
 
     /// <summary>
+    /// Call passes the data to the server and returns the response
+    /// </summary>
+    /// <param name="api">RosetteAPI object</param>
+    /// <returns>RosetteResponse</returns>
+    public override Response Call(ApiClient api) 
+    {
+        return Funcs.PostCall(api);
+    }
+
+    /// <summary>
     /// CallAsync passes the data to the server and returns the response asynchronously
     /// </summary>
     /// <param name="api">ApiClient object</param>
     /// <param name="cancellationToken">Optional cancellation token</param>
     /// <returns>Response</returns>
-    public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    public override Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
     {
         return Funcs.PostCallAsync(api, cancellationToken);
-    }
-
-    /// <summary>
-    /// Call passes the data to the server and returns the response
-    /// </summary>
-    /// <param name="api">RosetteAPI object</param>
-    /// <returns>RosetteResponse</returns>
-    public new Response Call(ApiClient api) 
-    {
-        return Funcs.PostCall(api);
     }
 }

--- a/rosette_api/Endpoints/Core/ContentEndpointBase.cs
+++ b/rosette_api/Endpoints/Core/ContentEndpointBase.cs
@@ -99,7 +99,7 @@ public abstract class ContentEndpointBase<T> : EndpointBase<T> where T : Content
     /// <param name="api">ApiClient object</param>
     /// <param name="cancellationToken">Optional cancellation token</param>
     /// <returns>Response</returns>
-    public Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
     {
         return Funcs.PostCallAsync(api, cancellationToken);
     }
@@ -109,7 +109,7 @@ public abstract class ContentEndpointBase<T> : EndpointBase<T> where T : Content
     /// </summary>
     /// <param name="api">RosetteAPI object</param>
     /// <returns>RosetteResponse</returns>
-    public Response Call(ApiClient api) 
+    public new Response Call(ApiClient api) 
     {
         return Funcs.PostCall(api);
     }

--- a/rosette_api/Endpoints/Core/ContentEndpointBase.cs
+++ b/rosette_api/Endpoints/Core/ContentEndpointBase.cs
@@ -1,6 +1,6 @@
-using Rosette.Api.Models;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints.Core;
+namespace Rosette.Api.Client.Endpoints.Core;
 
 /// <summary>
 /// Abstract base class for Rosette API endpoints that accept content and common parameters

--- a/rosette_api/Endpoints/Core/ContentEndpointBase.cs
+++ b/rosette_api/Endpoints/Core/ContentEndpointBase.cs
@@ -94,6 +94,17 @@ public abstract class ContentEndpointBase<T> : EndpointBase<T> where T : Content
     public string Filename => Funcs.Filename;
 
     /// <summary>
+    /// CallAsync passes the data to the server and returns the response asynchronously
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response</returns>
+    public Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    {
+        return Funcs.PostCallAsync(api, cancellationToken);
+    }
+
+    /// <summary>
     /// Call passes the data to the server and returns the response
     /// </summary>
     /// <param name="api">RosetteAPI object</param>

--- a/rosette_api/Endpoints/Core/EndpointBase.cs
+++ b/rosette_api/Endpoints/Core/EndpointBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using Rosette.Api.Models;
+using System.Collections.Specialized;
 
 namespace Rosette.Api.Endpoints.Core;
 
@@ -87,5 +88,23 @@ public class EndpointBase<T> where T : EndpointBase<T>
         UrlParameters.Remove(parameterKey);
         return (T)this;
     }
+
+    /// <summary>
+    /// CallAsync passes the data to the server and returns the response asynchronously
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response</returns>
+    public Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    {
+        return Funcs.GetCallAsync(api, cancellationToken);
+    }
+
+    /// <summary>
+    /// Call passes the data to the server and returns the response
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <returns>Response</returns>
+    public Response Call(ApiClient api) => Funcs.GetCall(api);
 
 }

--- a/rosette_api/Endpoints/Core/EndpointBase.cs
+++ b/rosette_api/Endpoints/Core/EndpointBase.cs
@@ -1,7 +1,7 @@
-﻿using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Models;
 using System.Collections.Specialized;
 
-namespace Rosette.Api.Endpoints.Core;
+namespace Rosette.Api.Client.Endpoints.Core;
 
 public class EndpointBase<T> where T : EndpointBase<T>
 {

--- a/rosette_api/Endpoints/Core/EndpointBase.cs
+++ b/rosette_api/Endpoints/Core/EndpointBase.cs
@@ -95,7 +95,7 @@ public class EndpointBase<T> where T : EndpointBase<T>
     /// <param name="api">ApiClient object</param>
     /// <param name="cancellationToken">Optional cancellation token</param>
     /// <returns>Response</returns>
-    public Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    public virtual Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
     {
         return Funcs.GetCallAsync(api, cancellationToken);
     }
@@ -105,6 +105,6 @@ public class EndpointBase<T> where T : EndpointBase<T>
     /// </summary>
     /// <param name="api">ApiClient object</param>
     /// <returns>Response</returns>
-    public Response Call(ApiClient api) => Funcs.GetCall(api);
+    public virtual Response Call(ApiClient api) => Funcs.GetCall(api);
 
 }

--- a/rosette_api/Endpoints/Core/EndpointExecutor.cs
+++ b/rosette_api/Endpoints/Core/EndpointExecutor.cs
@@ -17,6 +17,7 @@ public class EndpointExecutor {
     private const string LANGUAGE = "language";
     private const string GENRE = "genre";
     private const string OPTIONS = "options";
+    private const string HTTP_MEDIA_TYPE = "application/json";
 
     /// <summary>
     /// _params contains the parameters to be sent to the server
@@ -132,30 +133,39 @@ public class EndpointExecutor {
     }
 
     /// <summary>
-    /// GetCall executes the endpoint against the server using GetAsync
+    /// GetCallAsync executes the endpoint against the server using GetAsync
     /// </summary>
-    /// <param name="api">RosetteAPI object</param>
-    /// <returns>RosetteResponse</returns>
-    public Response GetCall(ApiClient api) {
+    /// <param name="api">ApiClient object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response</returns>
+    public async Task<Response> GetCallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    {
         string url = api.URI + Endpoint;
-        Task<HttpResponseMessage> task = Task.Run<HttpResponseMessage>(async () => await api.Client.GetAsync(url));
-        var response = task.Result;
-
-        return new Response(response);
+        var responseMsg = await api.Client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        return await Response.CreateAsync(responseMsg).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Call calls the server with the provided data using PostAsync
+    /// GetCall executes the endpoint against the server using GetAsync
     /// </summary>
-    /// <param name="api">RosetteAPI object</param>
-    /// <returns>Rosette Response</returns>
-    public virtual Response PostCall(ApiClient api)
+    /// <param name="api">ApiClient object</param>
+    /// <returns>Response</returns>
+    public Response GetCall(ApiClient api)
+    {
+        return GetCallAsync(api).GetAwaiter().GetResult();
+    }
+
+    /// PostCallAsync calls the server with the provided data using PostAsync
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response</returns>
+    public virtual async Task<Response> PostCallAsync(ApiClient api, CancellationToken cancellationToken = default)
     {
         string url = api.URI + Endpoint + ToQueryString();
 
         if (Filestream == null)
         {
-            // Use relaxed encoder to send actual Unicode characters
             var serializeOptions = new JsonSerializerOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
@@ -164,18 +174,26 @@ public class EndpointExecutor {
             HttpContent content = new StringContent(
                 JsonSerializer.Serialize(AppendOptions(_params), serializeOptions),
                 Encoding.UTF8,
-                "application/json"
+                HTTP_MEDIA_TYPE
             );
 
-            Task<HttpResponseMessage> task = Task.Run<HttpResponseMessage>(async () => await api.Client.PostAsync(url, content));
-            var response = task.Result;
-
-            return new Response(response);
+            var responseMsg = await api.Client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
+            return await Response.CreateAsync(responseMsg).ConfigureAwait(false);
         }
         else
         {
-            return PostAsMultipart(api, url);
+            return await PostAsMultipartAsync(api, url, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// PostCall calls the server with the provided data using PostAsync
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <returns>Response</returns>
+    public virtual Response PostCall(ApiClient api)
+    {
+        return PostCallAsync(api).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -191,6 +209,43 @@ public class EndpointExecutor {
             dict.Remove(OPTIONS); // Remove returns false if key doesn't exist, no need to check
         }
         return dict;
+    }
+
+    /// <summary>
+    /// PostAsMultipartAsync handles processing of files as a multipart upload
+    /// </summary>
+    /// <param name="api">ApiClient object</param>
+    /// <param name="url">Endpoint URL</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response object</returns>
+    private async Task<Response> PostAsMultipartAsync(ApiClient api, string url, CancellationToken cancellationToken = default)
+    {
+        using (var multiPartContent = new MultipartFormDataContent())
+        {
+            var streamContent = new StreamContent(Filestream);
+            streamContent.Headers.Add("Content-Type", FileContentType);
+            streamContent.Headers.Add("Content-Disposition", "mixed; name=\"content\"; filename=\"" + Path.GetFileName(Filestream.Name) + "\"");
+            multiPartContent.Add(streamContent, "content", Path.GetFileName(Filestream.Name));
+
+            if (_options.Count > 0 || _params.Count > 0)
+            {
+                var serializeOptions = new JsonSerializerOptions
+                {
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                };
+
+                var stringContent = new StringContent(
+                    JsonSerializer.Serialize(AppendOptions(_params), serializeOptions),
+                    Encoding.UTF8,
+                    HTTP_MEDIA_TYPE
+                );
+                stringContent.Headers.Add("Content-Disposition", "mixed; name=\"request\"");
+                multiPartContent.Add(stringContent, "request");
+            }
+
+            var responseMsg = await api.Client.PostAsync(url, multiPartContent, cancellationToken).ConfigureAwait(false);
+            return await Response.CreateAsync(responseMsg).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -218,7 +273,7 @@ public class EndpointExecutor {
                 var stringContent = new StringContent(
                     JsonSerializer.Serialize(AppendOptions(_params), serializeOptions),
                     Encoding.UTF8,
-                    "application/json"
+                    HTTP_MEDIA_TYPE
                 );
                 stringContent.Headers.Add("Content-Disposition", "mixed; name=\"request\"");
                 _multiPartContent.Add(stringContent, "request");
@@ -260,11 +315,4 @@ public class EndpointExecutor {
         return sb.ToString();
     }
 
-    /// <summary>
-    /// HasContent checks for content to send
-    /// </summary>
-    /// <returns>bool if content, contenturi or filename</returns>
-    private bool HasContent() {
-        return _params.ContainsKey(CONTENT) || _params.ContainsKey(CONTENTURI) || !string.IsNullOrEmpty(Filename);
-    }
 }

--- a/rosette_api/Endpoints/Core/EndpointExecutor.cs
+++ b/rosette_api/Endpoints/Core/EndpointExecutor.cs
@@ -1,10 +1,10 @@
-﻿using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Models;
 using System.Collections.Specialized;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
-namespace Rosette.Api.Endpoints.Core;
+namespace Rosette.Api.Client.Endpoints.Core;
 
 /// <summary>
 /// EndpointProcessor provices the compilation and processing of the endpoint

--- a/rosette_api/Endpoints/Core/EndpointExecutor.cs
+++ b/rosette_api/Endpoints/Core/EndpointExecutor.cs
@@ -249,43 +249,6 @@ public class EndpointExecutor {
     }
 
     /// <summary>
-    /// PostAsMultipart handles processing of files as a multipart upload
-    /// </summary>
-    /// <param name="api">RosetteAPI object</param>
-    /// <param name="url">Endpoint URL</param>
-    /// <returns>RosetteResponse object</returns>
-    private Response PostAsMultipart(ApiClient api, string url)
-    {
-        using (var _multiPartContent = new MultipartFormDataContent())
-        {
-            var streamContent = new StreamContent(Filestream);
-            streamContent.Headers.Add("Content-Type", FileContentType);
-            streamContent.Headers.Add("Content-Disposition", "mixed; name=\"content\"; filename=\"" + Path.GetFileName(Filestream.Name) + "\"");
-            _multiPartContent.Add(streamContent, "content", Path.GetFileName(Filestream.Name));
-
-            if (_options.Count > 0 || _params.Count > 0)
-            {
-                var serializeOptions = new JsonSerializerOptions
-                {
-                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-                };
-
-                var stringContent = new StringContent(
-                    JsonSerializer.Serialize(AppendOptions(_params), serializeOptions),
-                    Encoding.UTF8,
-                    HTTP_MEDIA_TYPE
-                );
-                stringContent.Headers.Add("Content-Disposition", "mixed; name=\"request\"");
-                _multiPartContent.Add(stringContent, "request");
-            }
-
-            Task<HttpResponseMessage> task = Task.Run<HttpResponseMessage>(async () => await api.Client.PostAsync(url, _multiPartContent));
-            var response = task.Result;
-            return new Response(response);
-        }
-    }
-
-    /// <summary>
     /// clearKey removes the specified key from the _params dictionary
     /// </summary>
     /// <param name="key">key name</param>

--- a/rosette_api/Endpoints/Entities.cs
+++ b/rosette_api/Endpoints/Entities.cs
@@ -8,7 +8,6 @@ public class Entities : ContentEndpointBase<Entities>
     /// EntitiesEndpoint returns the entities extracted from the endpoint
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Entities(object content) : base("entities", content)
-    {
-    }
+    public Entities(object content) : base("entities", content) { }
 }
+

--- a/rosette_api/Endpoints/Entities.cs
+++ b/rosette_api/Endpoints/Entities.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Entities : ContentEndpointBase<Entities>
 {

--- a/rosette_api/Endpoints/Events.cs
+++ b/rosette_api/Endpoints/Events.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Events : ContentEndpointBase<Events>
 {

--- a/rosette_api/Endpoints/Events.cs
+++ b/rosette_api/Endpoints/Events.cs
@@ -8,7 +8,5 @@ public class Events : ContentEndpointBase<Events>
     /// EventsEndpoint returns the events extracted from the endpoint
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Events(object content) : base("events", content)
-    {
-    }
+    public Events(object content) : base("events", content) { }
 }

--- a/rosette_api/Endpoints/Info.cs
+++ b/rosette_api/Endpoints/Info.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class Info : EndpointBase<Info>
     {

--- a/rosette_api/Endpoints/Info.cs
+++ b/rosette_api/Endpoints/Info.cs
@@ -1,12 +1,9 @@
 ﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
 
 namespace Rosette.Api.Endpoints
 {
     public class Info : EndpointBase<Info>
     {
         public Info() : base("info") { }
-
-        public Response Call(ApiClient api) => Funcs.GetCall(api);
     }
 }

--- a/rosette_api/Endpoints/Language.cs
+++ b/rosette_api/Endpoints/Language.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Language : ContentEndpointBase<Language>
 {

--- a/rosette_api/Endpoints/Language.cs
+++ b/rosette_api/Endpoints/Language.cs
@@ -8,7 +8,6 @@ public class Language : ContentEndpointBase<Language>
     /// LanguageEndpoint returns the language extracted from the endpoint
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Language(object content) : base("language", content)
-    {
-    }
+    public Language(object content) : base("language", content) { }
 }
+

--- a/rosette_api/Endpoints/Morphology.cs
+++ b/rosette_api/Endpoints/Morphology.cs
@@ -1,7 +1,7 @@
-﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public enum MorphologyFeature {
         /// <summary>provide complete morphology</summary>

--- a/rosette_api/Endpoints/Morphology.cs
+++ b/rosette_api/Endpoints/Morphology.cs
@@ -77,14 +77,7 @@ namespace Rosette.Api.Endpoints
         }
         public string FileContentType => Funcs.FileContentType;
         public string Filename => Funcs.Filename;
-        /// <summary>
-        /// Call passes the data to the server and returns the response
-        /// </summary>
-        /// <param name="api">RosetteAPI object</param>
-        /// <returns>RosetteResponse</returns>
-        public Response Call(ApiClient api) {
-            return Funcs.PostCall(api);
-        }
+
         /// <summary>
         /// FeatureAsString returns the feature enum in its endpoint string form
         /// </summary>
@@ -102,5 +95,14 @@ namespace Rosette.Api.Endpoints
             return _featureEndpoint[feature];
         }
 
+        public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+        {
+            return Funcs.PostCallAsync(api, cancellationToken);
+        }
+
+        public new Response Call(ApiClient api)
+        {
+            return Funcs.PostCall(api);
+        }
     }
 }

--- a/rosette_api/Endpoints/NameDeduplication.cs
+++ b/rosette_api/Endpoints/NameDeduplication.cs
@@ -1,7 +1,7 @@
-﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class NameDeduplication : EndpointBase<NameDeduplication>
     {

--- a/rosette_api/Endpoints/NameDeduplication.cs
+++ b/rosette_api/Endpoints/NameDeduplication.cs
@@ -12,6 +12,7 @@ namespace Rosette.Api.Endpoints
         public NameDeduplication(List<Name> names) : base("name-deduplication") {
             SetNames(names);
         }
+
         /// <summary>
         /// SetNames assigns a list of RosetteName objects to be processed
         /// </summary>
@@ -24,6 +25,7 @@ namespace Rosette.Api.Endpoints
             Params["names"] = names;
             return this;
         }
+
         /// <summary>
         /// Names returns the list of RosetteName objects
         /// </summary>
@@ -32,6 +34,7 @@ namespace Rosette.Api.Endpoints
                 Params["names"] as IList<Name> :
                 null;
         }
+
         /// <summary>
         /// SetProfileID sets a profile ID to be used during processing
         /// </summary>
@@ -41,6 +44,7 @@ namespace Rosette.Api.Endpoints
             Params["profileid"] = profileID;
             return this;
         }
+
         /// <summary>
         /// ProfileID returns the profile ID or empty string
         /// </summary>
@@ -49,6 +53,7 @@ namespace Rosette.Api.Endpoints
                 Params["profileid"].ToString() :
                 string.Empty;
         }
+
         /// <summary>
         /// SetThreshold sets the threshold to be used for determining deduplication cluster sizing
         /// </summary>
@@ -58,6 +63,7 @@ namespace Rosette.Api.Endpoints
             Params["threshold"] = threshold;
             return this;
         }
+
         /// <summary>
         /// Threshold returns the threshold or the default, 0.75f
         /// </summary>
@@ -66,14 +72,15 @@ namespace Rosette.Api.Endpoints
                 (float)Params["threshold"] :
                 0.75f;
         }
-        /// <summary>
-        /// Call returns the response from the server
-        /// </summary>
-        /// <param name="api">RosetteAPI object</param>
-        /// <returns>RosetteResponse</returns>
-        public Response Call(ApiClient api) {
-            return Funcs.PostCall(api);
+
+        public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+        {
+            return Funcs.PostCallAsync(api, cancellationToken);
         }
 
+        public new Response Call(ApiClient api)
+        {
+            return Funcs.PostCall(api);
+        }
     }
 }

--- a/rosette_api/Endpoints/NameSimilarity.cs
+++ b/rosette_api/Endpoints/NameSimilarity.cs
@@ -16,7 +16,13 @@ namespace Rosette.Api.Endpoints
             Params["name2"] = name2;
         }
 
-        public Response Call(ApiClient api) {
+        public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+        {
+            return Funcs.PostCallAsync(api, cancellationToken);
+        }
+
+        public new Response Call(ApiClient api)
+        {
             return Funcs.PostCall(api);
         }
     }

--- a/rosette_api/Endpoints/NameSimilarity.cs
+++ b/rosette_api/Endpoints/NameSimilarity.cs
@@ -1,7 +1,7 @@
-﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class NameSimilarity : EndpointBase<NameSimilarity> {
         /// <summary>

--- a/rosette_api/Endpoints/NameTranslation.cs
+++ b/rosette_api/Endpoints/NameTranslation.cs
@@ -19,6 +19,7 @@ namespace Rosette.Api.Endpoints
             SetName(name);
             SetTargetLanguage(targetLanguage);
         }
+
         /// <summary>
         /// SetName defines the name to be translated
         /// </summary>
@@ -29,11 +30,13 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? Name { get =>
                 Params.ContainsKey(NAME) ?
                 Params[NAME].ToString() :
                 string.Empty;
         }
+
         /// <summary>
         /// SetEntityType sets the optional entity type, PERSON, LOCATION or ORGANIZATION
         /// </summary>
@@ -44,11 +47,13 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? EntityType { get =>
                 Params.ContainsKey(ENTITY_TYPE) ?
                 Params[ENTITY_TYPE].ToString() :
                 string.Empty;
         }
+
         /// <summary>
         /// SetSourceLanguageOfOrigin sets the optional ISO 639-3 code for the name's language of origin
         /// </summary>
@@ -59,6 +64,7 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? SourceLanguageOfOrigin { get =>
                 Params.ContainsKey(SOURCE_LANGUAGE_OF_ORIGIN) ?
                 Params[SOURCE_LANGUAGE_OF_ORIGIN].ToString() :
@@ -74,11 +80,13 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? SourceLanguageOfUse { get =>
                 Params.ContainsKey(SOURCE_LANGUAGE_OF_USE) ?
                 Params[SOURCE_LANGUAGE_OF_USE].ToString() :
                 String.Empty;
         }
+
         /// <summary>
         /// SetSourceScript sets the optional ISO 15924 code for the name's script
         /// </summary>
@@ -94,6 +102,7 @@ namespace Rosette.Api.Endpoints
                 Params[SOURCE_SCRIPT].ToString() :
                 string.Empty;
         }
+
         /// <summary>
         /// SetTargetLanguage sets the ISO 639-3 code for the translation language.
         /// Defaults to "eng"
@@ -105,11 +114,13 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? TargetLanguage { get =>
                 Params.ContainsKey(TARGET_LANGUAGE) ?
                 Params[TARGET_LANGUAGE].ToString() :
                 String.Empty;
         }
+
         /// <summary>
         /// SetTargetScheme sets the optional transliteration scheme for the translation
         /// </summary>
@@ -120,11 +131,13 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? TargetScheme { get =>
                 Params.ContainsKey(TARGET_SCHEME) ?
                 Params[TARGET_SCHEME].ToString() :
                 string.Empty;
         }
+
         /// <summary>
         /// SetTargetScript sets the optional ISO 15924 code for the translation script
         /// </summary>
@@ -135,6 +148,7 @@ namespace Rosette.Api.Endpoints
 
             return this;
         }
+
         public string? TargetScript { get => Params.ContainsKey(TARGET_SCRIPT) ?
                 Params[TARGET_SCRIPT].ToString() :
                 string.Empty;
@@ -158,7 +172,13 @@ namespace Rosette.Api.Endpoints
                 null;
         }
 
-        public Response Call(ApiClient api) {
+        public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+        {
+            return Funcs.PostCallAsync(api, cancellationToken);
+        }
+
+        public new Response Call(ApiClient api)
+        {
             return Funcs.PostCall(api);
         }
     }

--- a/rosette_api/Endpoints/NameTranslation.cs
+++ b/rosette_api/Endpoints/NameTranslation.cs
@@ -1,7 +1,7 @@
-﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class NameTranslation : EndpointBase<NameTranslation>
     {

--- a/rosette_api/Endpoints/Ping.cs
+++ b/rosette_api/Endpoints/Ping.cs
@@ -1,12 +1,9 @@
 ﻿using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
 
 namespace Rosette.Api.Endpoints
 {
     public class Ping : EndpointBase<Ping>
     {
         public Ping() : base("ping") { }
-
-        public Response Call(ApiClient api) => Funcs.GetCall(api);
     }
 }

--- a/rosette_api/Endpoints/Ping.cs
+++ b/rosette_api/Endpoints/Ping.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Client.Endpoints
 {
     public class Ping : EndpointBase<Ping>
     {

--- a/rosette_api/Endpoints/RecordSimilarity.cs
+++ b/rosette_api/Endpoints/RecordSimilarity.cs
@@ -21,7 +21,12 @@ public class RecordSimilarity : EndpointBase<RecordSimilarity>
         Params["records"] = records;
     }
 
-    public Response Call(ApiClient api)
+    public new Task<Response> CallAsync(ApiClient api, CancellationToken cancellationToken = default)
+    {
+        return Funcs.PostCallAsync(api, cancellationToken);
+    }
+
+    public new Response Call(ApiClient api)
     {
         return Funcs.PostCall(api);
     }

--- a/rosette_api/Endpoints/RecordSimilarity.cs
+++ b/rosette_api/Endpoints/RecordSimilarity.cs
@@ -1,7 +1,7 @@
-using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class RecordSimilarity : EndpointBase<RecordSimilarity>
 {

--- a/rosette_api/Endpoints/Relationships.cs
+++ b/rosette_api/Endpoints/Relationships.cs
@@ -8,7 +8,5 @@ public class Relationships : ContentEndpointBase<Relationships>
     /// RelationshipsEndpoint returns the relationships between entities in the input text
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Relationships(object content) : base("relationships", content)
-    {
-    }
+    public Relationships(object content) : base("relationships", content) { }
 }

--- a/rosette_api/Endpoints/Relationships.cs
+++ b/rosette_api/Endpoints/Relationships.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Relationships : ContentEndpointBase<Relationships>
 {

--- a/rosette_api/Endpoints/SemanticsVector.cs
+++ b/rosette_api/Endpoints/SemanticsVector.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class SemanticsVector : ContentEndpointBase<SemanticsVector>
 {

--- a/rosette_api/Endpoints/SemanticsVector.cs
+++ b/rosette_api/Endpoints/SemanticsVector.cs
@@ -8,7 +8,5 @@ public class SemanticsVector : ContentEndpointBase<SemanticsVector>
     /// SemanticVectorsEndpoint returns the relationships between entities in the input text
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public SemanticsVector(object content) : base("semantics/vector", content)
-    {
-    }
+    public SemanticsVector(object content) : base("semantics/vector", content) { }
 }

--- a/rosette_api/Endpoints/Sentences.cs
+++ b/rosette_api/Endpoints/Sentences.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Sentences : ContentEndpointBase<Sentences> {
     /// <summary>

--- a/rosette_api/Endpoints/Sentences.cs
+++ b/rosette_api/Endpoints/Sentences.cs
@@ -1,13 +1,11 @@
 ﻿using Rosette.Api.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints
-{
-    public class Sentences : ContentEndpointBase<Sentences> {
-        /// <summary>
-        /// SentencesEndpoint returns each entity extracted from the input
-        /// </summary>
-        /// <param name="content">text, Uri object or FileStream</param>
-        public Sentences(object content) : base("sentences", content) {
-        }
-    }
+namespace Rosette.Api.Endpoints;
+
+public class Sentences : ContentEndpointBase<Sentences> {
+    /// <summary>
+    /// SentencesEndpoint returns each entity extracted from the input
+    /// </summary>
+    /// <param name="content">text, Uri object or FileStream</param>
+    public Sentences(object content) : base("sentences", content) { }
 }

--- a/rosette_api/Endpoints/Sentiment.cs
+++ b/rosette_api/Endpoints/Sentiment.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Sentiment : ContentEndpointBase<Sentiment>
 {

--- a/rosette_api/Endpoints/Sentiment.cs
+++ b/rosette_api/Endpoints/Sentiment.cs
@@ -1,15 +1,12 @@
 ﻿using Rosette.Api.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Endpoints;
+
+public class Sentiment : ContentEndpointBase<Sentiment>
 {
-    public class Sentiment : ContentEndpointBase<Sentiment>
-    {
-        /// <summary>
-        /// SentimentEndpoint analyzes the positive and negative sentiment expressed by the input
-        /// </summary>
-        /// <param name="content">text, Uri object or FileStream</param>
-        public Sentiment(object content) : base("sentiment", content)
-        {
-        }
-    }
+    /// <summary>
+    /// SentimentEndpoint analyzes the positive and negative sentiment expressed by the input
+    /// </summary>
+    /// <param name="content">text, Uri object or FileStream</param>
+    public Sentiment(object content) : base("sentiment", content) { }
 }

--- a/rosette_api/Endpoints/SimilarTerms.cs
+++ b/rosette_api/Endpoints/SimilarTerms.cs
@@ -1,6 +1,6 @@
-using Rosette.Api.Endpoints.Core;
+using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class SimilarTerms : ContentEndpointBase<SimilarTerms>
 {

--- a/rosette_api/Endpoints/SimilarTerms.cs
+++ b/rosette_api/Endpoints/SimilarTerms.cs
@@ -8,7 +8,5 @@ public class SimilarTerms : ContentEndpointBase<SimilarTerms>
     /// SimilarTerms returns terms that are similar to the input
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public SimilarTerms(object content) : base("semantics/similar", content)
-    {
-    }
+    public SimilarTerms(object content) : base("semantics/similar", content) { }
 }

--- a/rosette_api/Endpoints/SyntaxDependencies.cs
+++ b/rosette_api/Endpoints/SyntaxDependencies.cs
@@ -7,6 +7,5 @@ public class SyntaxDependencies : ContentEndpointBase<SyntaxDependencies> {
     /// SyntaxDependenciesEndpoint returns the parse tree of the input text as a list of labeled directed links between tokens, as well as the list of tokens in the input sentence
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public SyntaxDependencies(object content) : base("syntax/dependencies", content) {
-    }
+    public SyntaxDependencies(object content) : base("syntax/dependencies", content) { }
 }

--- a/rosette_api/Endpoints/SyntaxDependencies.cs
+++ b/rosette_api/Endpoints/SyntaxDependencies.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class SyntaxDependencies : ContentEndpointBase<SyntaxDependencies> {
     /// <summary>

--- a/rosette_api/Endpoints/TextEmbedding.cs
+++ b/rosette_api/Endpoints/TextEmbedding.cs
@@ -1,15 +1,12 @@
 ﻿using Rosette.Api.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints
+namespace Rosette.Api.Endpoints;
+
+public class TextEmbedding : ContentEndpointBase<TextEmbedding>
 {
-    public class TextEmbedding : ContentEndpointBase<TextEmbedding>
-    {
-        /// <summary>
-        /// TextEmbeddingEndpoint returns the embedding for the input text
-        /// </summary>
-        /// <param name="content">text, Uri object or FileStream</param>
-        public TextEmbedding(object content) : base("text-embedding", content)
-        {
-        }
-    }
+    /// <summary>
+    /// TextEmbeddingEndpoint returns the embedding for the input text
+    /// </summary>
+    /// <param name="content">text, Uri object or FileStream</param>
+    public TextEmbedding(object content) : base("text-embedding", content) { }
 }

--- a/rosette_api/Endpoints/TextEmbedding.cs
+++ b/rosette_api/Endpoints/TextEmbedding.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class TextEmbedding : ContentEndpointBase<TextEmbedding>
 {

--- a/rosette_api/Endpoints/Tokens.cs
+++ b/rosette_api/Endpoints/Tokens.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Tokens : ContentEndpointBase<Tokens> {
     /// <summary>

--- a/rosette_api/Endpoints/Tokens.cs
+++ b/rosette_api/Endpoints/Tokens.cs
@@ -7,6 +7,5 @@ public class Tokens : ContentEndpointBase<Tokens> {
     /// TokensEndpoint returns each entity extracted from the input
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Tokens(object content) : base("tokens", content) {
-    }
+    public Tokens(object content) : base("tokens", content) { }
 }

--- a/rosette_api/Endpoints/Topics.cs
+++ b/rosette_api/Endpoints/Topics.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Topics : ContentEndpointBase<Topics> {
     /// <summary>

--- a/rosette_api/Endpoints/Topics.cs
+++ b/rosette_api/Endpoints/Topics.cs
@@ -7,6 +7,5 @@ public class Topics : ContentEndpointBase<Topics> {
     /// TopicsEndpoint returns the topic extracted from the endpoint
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Topics(object content) : base("topics", content) {
-    }
+    public Topics(object content) : base("topics", content) { }
 }

--- a/rosette_api/Endpoints/Transliteration.cs
+++ b/rosette_api/Endpoints/Transliteration.cs
@@ -1,6 +1,6 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
-namespace Rosette.Api.Endpoints;
+namespace Rosette.Api.Client.Endpoints;
 
 public class Transliteration : ContentEndpointBase<Transliteration> {
     /// <summary>

--- a/rosette_api/Endpoints/Transliteration.cs
+++ b/rosette_api/Endpoints/Transliteration.cs
@@ -7,6 +7,5 @@ public class Transliteration : ContentEndpointBase<Transliteration> {
     /// TransliterationEndpoint returns the transliteration of the input
     /// </summary>
     /// <param name="content">text, Uri object or FileStream</param>
-    public Transliteration(object content) : base("transliteration", content) {
-    }
+    public Transliteration(object content) : base("transliteration", content) { }
 }

--- a/rosette_api/Models/AddressField.cs
+++ b/rosette_api/Models/AddressField.cs
@@ -1,4 +1,4 @@
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Abstract parent class for UnfieldedAddress and FieldedAddress

--- a/rosette_api/Models/BooleanRecord.cs
+++ b/rosette_api/Models/BooleanRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/BooleanRecord.cs
+++ b/rosette_api/Models/BooleanRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing a boolean record

--- a/rosette_api/Models/DateField.cs
+++ b/rosette_api/Models/DateField.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Abstract parent class for UnfieldedDate and FieldedDate

--- a/rosette_api/Models/EntityType.cs
+++ b/rosette_api/Models/EntityType.cs
@@ -1,4 +1,4 @@
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Represents the type of entity for name processing

--- a/rosette_api/Models/FieldedAddressRecord.cs
+++ b/rosette_api/Models/FieldedAddressRecord.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing a fielded address

--- a/rosette_api/Models/FieldedDateRecord.cs
+++ b/rosette_api/Models/FieldedDateRecord.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing a fielded date

--- a/rosette_api/Models/FieldedNameRecord.cs
+++ b/rosette_api/Models/FieldedNameRecord.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary> 
 /// Class for representing a fielded name

--- a/rosette_api/Models/GenderType.cs
+++ b/rosette_api/Models/GenderType.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Possible gender options for the Name objects

--- a/rosette_api/Models/GenderType.cs
+++ b/rosette_api/Models/GenderType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json.Serialization;
-
-namespace Rosette.Api.Client.Models;
+﻿namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Possible gender options for the Name objects

--- a/rosette_api/Models/JsonConverter/RecordSimilarityFieldConverter.cs
+++ b/rosette_api/Models/JsonConverter/RecordSimilarityFieldConverter.cs
@@ -1,9 +1,7 @@
-using Rosette.Api.Client.Models;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
-namespace rosette_api.Models.JsonConverter;
+namespace Rosette.Api.Client.Models.JsonConverter;
 
 /// <summary>
 /// JsonConverter for RecordSimilarityField interface polymorphic serialization

--- a/rosette_api/Models/JsonConverter/RecordSimilarityFieldConverter.cs
+++ b/rosette_api/Models/JsonConverter/RecordSimilarityFieldConverter.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Models;
+using Rosette.Api.Client.Models;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;

--- a/rosette_api/Models/JsonConverter/RecordSimilarityRecordsConverter.cs
+++ b/rosette_api/Models/JsonConverter/RecordSimilarityRecordsConverter.cs
@@ -1,4 +1,4 @@
-﻿using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Models;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/rosette_api/Models/JsonConverter/RecordSimilarityRecordsConverter.cs
+++ b/rosette_api/Models/JsonConverter/RecordSimilarityRecordsConverter.cs
@@ -1,8 +1,7 @@
-﻿using Rosette.Api.Client.Models;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace rosette_api.Models.JsonConverter;
+namespace Rosette.Api.Client.Models.JsonConverter;
 
 /// <summary>
 /// JsonConverter for RecordSimilarityRecords to properly serialize RecordSimilarityField values

--- a/rosette_api/Models/JsonConverter/UnfieldedRecordSimilarityConverter.cs
+++ b/rosette_api/Models/JsonConverter/UnfieldedRecordSimilarityConverter.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Models;
+using Rosette.Api.Client.Models;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/rosette_api/Models/JsonConverter/UnfieldedRecordSimilarityConverter.cs
+++ b/rosette_api/Models/JsonConverter/UnfieldedRecordSimilarityConverter.cs
@@ -1,8 +1,7 @@
-using Rosette.Api.Client.Models;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace rosette_api.Models.JsonConverter;
+namespace Rosette.Api.Client.Models.JsonConverter;
 
 /// <summary>
 /// JsonConverter for Unfielded Record Similarity objects

--- a/rosette_api/Models/Name.cs
+++ b/rosette_api/Models/Name.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 public class Name
 {

--- a/rosette_api/Models/NameField.cs
+++ b/rosette_api/Models/NameField.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Abstract parent class for UnfieldedName and FieldedName

--- a/rosette_api/Models/NumberRecord.cs
+++ b/rosette_api/Models/NumberRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing a number record

--- a/rosette_api/Models/NumberRecord.cs
+++ b/rosette_api/Models/NumberRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/RecordFieldType.cs
+++ b/rosette_api/Models/RecordFieldType.cs
@@ -1,4 +1,4 @@
-﻿namespace Rosette.Api.Models;
+﻿namespace Rosette.Api.Client.Models;
 
 /// <summary>RecordFieldType
 /// <para>

--- a/rosette_api/Models/RecordSimilarityField.cs
+++ b/rosette_api/Models/RecordSimilarityField.cs
@@ -1,4 +1,4 @@
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Parent Interface for RecordSimilarityField objects

--- a/rosette_api/Models/RecordSimilarityFieldInfo.cs
+++ b/rosette_api/Models/RecordSimilarityFieldInfo.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models {
+namespace Rosette.Api.Client.Models {
 
     /// <summary>
     /// Class for representing record similarity field information

--- a/rosette_api/Models/RecordSimilarityProperties.cs
+++ b/rosette_api/Models/RecordSimilarityProperties.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models
+namespace Rosette.Api.Client.Models
 {
     public class RecordSimilarityProperties
     {

--- a/rosette_api/Models/RecordSimilarityRecords.cs
+++ b/rosette_api/Models/RecordSimilarityRecords.cs
@@ -1,4 +1,4 @@
-﻿using rosette_api.Models.JsonConverter;
+﻿using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/rosette_api/Models/RecordSimilarityRecords.cs
+++ b/rosette_api/Models/RecordSimilarityRecords.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 [JsonConverter(typeof(RecordSimilarityRecordsConverter))]
 public class RecordSimilarityRecords

--- a/rosette_api/Models/Response.cs
+++ b/rosette_api/Models/Response.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 public class Response
 {

--- a/rosette_api/Models/Response.cs
+++ b/rosette_api/Models/Response.cs
@@ -7,92 +7,146 @@ namespace Rosette.Api.Models;
 
 public class Response
 {
-    public Response(HttpResponseMessage responseMsg) {
+    // Private constructor for async factory
+    private Response()
+    {
         Content = new Dictionary<string, object>();
         Headers = new Dictionary<string, string>();
+    }
 
+    // Keep existing synchronous constructor for backward compatibility
+    public Response(HttpResponseMessage responseMsg) : this()
+    {
         StatusCode = (int)responseMsg.StatusCode;
 
-        if (responseMsg.IsSuccessStatusCode) {
-            foreach (var header in responseMsg.Headers) {
-                Headers.Add(header.Key, string.Join("", header.Value));
-            }
-            foreach (var header in responseMsg.Content.Headers) {
-                Headers.Add(header.Key, string.Join("", header.Value));
-            }
+        if (responseMsg.IsSuccessStatusCode)
+        {
+            ProcessHeaders(responseMsg);
             byte[] byteArray = responseMsg.Content.ReadAsByteArrayAsync().Result;
-            if(byteArray[0] == '\x1f' && byteArray[1] == '\x8b' && byteArray[2] == '\x08') {
-                byteArray = Decompress(byteArray);
-            }
-            string result = string.Empty;
-            using (StreamReader reader = new StreamReader(new MemoryStream(byteArray), Encoding.UTF8)) {
-                result = reader.ReadToEnd();
-            }
-
+            string result = ProcessContent(byteArray);
             Content = JsonSerializer.Deserialize<Dictionary<string, object>>(result)!;
         }
-        else {
-            throw new HttpRequestException(string.Format("{0}: {1}: {2}", (int)responseMsg.StatusCode, responseMsg.ReasonPhrase, ContentToString(responseMsg.Content)));
+        else
+        {
+            throw new HttpRequestException(
+                $"{(int)responseMsg.StatusCode}: {responseMsg.ReasonPhrase}: {ContentToString(responseMsg.Content)}");
         }
+    }
+
+    /// <summary>
+    /// CreateAsync creates a Response asynchronously from an HttpResponseMessage
+    /// </summary>
+    /// <param name="responseMsg">HTTP response message</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>Response</returns>
+    public static async Task<Response> CreateAsync(HttpResponseMessage responseMsg, CancellationToken cancellationToken = default)
+    {
+        var response = new Response
+        {
+            StatusCode = (int)responseMsg.StatusCode
+        };
+
+        if (responseMsg.IsSuccessStatusCode)
+        {
+            response.ProcessHeaders(responseMsg);
+            byte[] byteArray = await responseMsg.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            string result = response.ProcessContent(byteArray);
+            response.Content = JsonSerializer.Deserialize<Dictionary<string, object>>(result)!;
+        }
+        else
+        {
+            string errorContent = await ContentToStringAsync(responseMsg.Content, cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"{(int)responseMsg.StatusCode}: {responseMsg.ReasonPhrase}: {errorContent}");
+        }
+
+        return response;
     }
 
     /// <summary>
     /// Headers provides read access to the Response Headers collection
     /// </summary>
-    /// <returns>IDictionary of string, string</returns>
-    public IDictionary<string, string> Headers {get; private set;}
+    public IDictionary<string, string> Headers { get; private set; }
 
     /// <summary>
     /// Content provides read access to the Response IDictionary
     /// </summary>
-    /// <returns>IDictionary of string, object</returns>
-    public IDictionary<string, object> Content {get; private set;}
+    public IDictionary<string, object> Content { get; private set; }
+
+    /// <summary>
+    /// StatusCode returns the HTTP status code
+    /// </summary>
+    public int StatusCode { get; private set; }
 
     public object ContentAsJson(bool pretty = false)
     {
         var options = new JsonSerializerOptions
         {
             WriteIndented = pretty,
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping  // Don't escape Unicode characters
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         return JsonSerializer.Serialize(Content, options);
     }
 
-    public int StatusCode {get; private set;}
+    private void ProcessHeaders(HttpResponseMessage responseMsg)
+    {
+        foreach (var header in responseMsg.Headers)
+        {
+            Headers.Add(header.Key, string.Join("", header.Value));
+        }
+        foreach (var header in responseMsg.Content.Headers)
+        {
+            Headers.Add(header.Key, string.Join("", header.Value));
+        }
+    }
 
+    private string ProcessContent(byte[] byteArray)
+    {
+        if (byteArray.Length >= 3 && byteArray[0] == '\x1f' && byteArray[1] == '\x8b' && byteArray[2] == '\x08')
+        {
+            byteArray = Decompress(byteArray);
+        }
 
-    /// <summary>Decompress decompresses GZIP files
-    /// Source: http://www.dotnetperls.com/decompress
-    /// </summary>
-    /// <param name="gzip">(byte[]): Data in byte form to decompress</param>
-    /// <returns>(byte[]) Decompressed data</returns>
-    private byte[] Decompress(byte[] gzip) {
-        // Create a GZIP stream with decompression mode.
-        // ... Then create a buffer and write into while reading from the GZIP stream.
-        using (GZipStream stream = new GZipStream(new MemoryStream(gzip), CompressionMode.Decompress)) {
+        using (StreamReader reader = new StreamReader(new MemoryStream(byteArray), Encoding.UTF8))
+        {
+            return reader.ReadToEnd();
+        }
+    }
+
+    private byte[] Decompress(byte[] gzip)
+    {
+        using (GZipStream stream = new GZipStream(new MemoryStream(gzip), CompressionMode.Decompress))
+        {
             const int size = 4096;
             byte[] buffer = new byte[size];
-            using (MemoryStream memory = new MemoryStream()) {
-                int count = 0;
-                do {
+            using (MemoryStream memory = new MemoryStream())
+            {
+                int count;
+                do
+                {
                     count = stream.Read(buffer, 0, size);
-                    if (count > 0) {
+                    if (count > 0)
+                    {
                         memory.Write(buffer, 0, count);
                     }
-                }
-                while (count > 0);
+                } while (count > 0);
                 return memory.ToArray();
             }
         }
     }
-    internal static string ContentToString(HttpContent httpContent) {
-        if (httpContent != null) {
-            var readAsStringAsync = httpContent.ReadAsStringAsync();
-            return readAsStringAsync.Result;
+
+    internal static string ContentToString(HttpContent httpContent)
+    {
+        return httpContent?.ReadAsStringAsync().Result ?? string.Empty;
+    }
+
+    internal static async Task<string> ContentToStringAsync(HttpContent httpContent, CancellationToken cancellationToken = default)
+    {
+        if (httpContent != null)
+        {
+            return await httpContent.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
-        else {
-            return string.Empty;
-        }
+        return string.Empty;
     }
 }

--- a/rosette_api/Models/StringRecord.cs
+++ b/rosette_api/Models/StringRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing a string record

--- a/rosette_api/Models/StringRecord.cs
+++ b/rosette_api/Models/StringRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/UnfieldedAddressRecord.cs
+++ b/rosette_api/Models/UnfieldedAddressRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing an unfielded address

--- a/rosette_api/Models/UnfieldedAddressRecord.cs
+++ b/rosette_api/Models/UnfieldedAddressRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/UnfieldedDateRecord.cs
+++ b/rosette_api/Models/UnfieldedDateRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/UnfieldedDateRecord.cs
+++ b/rosette_api/Models/UnfieldedDateRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing an unfielded date

--- a/rosette_api/Models/UnfieldedNameRecord.cs
+++ b/rosette_api/Models/UnfieldedNameRecord.cs
@@ -1,7 +1,7 @@
 using rosette_api.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing an unfielded name

--- a/rosette_api/Models/UnfieldedNameRecord.cs
+++ b/rosette_api/Models/UnfieldedNameRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Serialization;
 
 namespace Rosette.Api.Client.Models;

--- a/rosette_api/Models/UnknownFieldRecord.cs
+++ b/rosette_api/Models/UnknownFieldRecord.cs
@@ -2,7 +2,7 @@ using rosette_api.Models.JsonConverter;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
-namespace Rosette.Api.Models;
+namespace Rosette.Api.Client.Models;
 
 /// <summary>
 /// Class for representing an unknown field

--- a/rosette_api/Models/UnknownFieldRecord.cs
+++ b/rosette_api/Models/UnknownFieldRecord.cs
@@ -1,4 +1,4 @@
-using rosette_api.Models.JsonConverter;
+using Rosette.Api.Client.Models.JsonConverter;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 

--- a/rosette_api/Utilities.cs
+++ b/rosette_api/Utilities.cs
@@ -1,4 +1,4 @@
-﻿namespace Rosette.Api;
+﻿namespace Rosette.Api.Client;
 
 public static class Utilities
 {

--- a/tests/ApiClientTests.cs
+++ b/tests/ApiClientTests.cs
@@ -4,7 +4,7 @@ namespace Rosette.Api.Tests;
 
 public class ApiClientTests
 {
-    private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/";
+    private static readonly string _defaultUri = "https://analytics.babelstreet.com/rest/v1/";
     private static readonly string _testKey = "testKey";
         
     private static ApiClient Init() {

--- a/tests/ApiClientTests.cs
+++ b/tests/ApiClientTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Rosette.Api.Tests;
+﻿using Rosette.Api.Client;
+
+namespace Rosette.Api.Tests;
 
 public class ApiClientTests
 {

--- a/tests/ApiClientTests.cs
+++ b/tests/ApiClientTests.cs
@@ -1,96 +1,97 @@
-﻿namespace Rosette.Api.Tests
+﻿using Rosette.Api.Endpoints;
+
+namespace Rosette.Api.Tests;
+
+public class ApiClientTests
 {
-    public class ApiClientTests
-    {
-        private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/";
-        private static readonly string _testKey = "testKey";
+    private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/";
+    private static readonly string _testKey = "testKey";
 
-        private static ApiClient Init() {
-            return new ApiClient(_testKey);
-        }
+    private static ApiClient Init() {
+        return new ApiClient(_testKey);
+    }
 
-        [Fact]
-        public void TestKey() {
-            ApiClient api = Init();
-            Assert.Equal(_testKey, api.APIKey);
-        }
+    [Fact]
+    public void TestKey() {
+        ApiClient api = Init();
+        Assert.Equal(_testKey, api.APIKey);
+    }
 
-        [Fact]
-        public void TestNullKey() {
+    [Fact]
+    public void TestNullKey() {
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-            string key = null;
+        string key = null;
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning disable CS8604 // Possible null reference argument.
-            Exception ex = Assert.Throws<ArgumentNullException>(() => new ApiClient(key));
+        Exception ex = Assert.Throws<ArgumentNullException>(() => new ApiClient(key));
 #pragma warning restore CS8604 // Possible null reference argument.
 
-            Assert.Equal("Value cannot be null. (Parameter 'apiKey')", ex.Message);
-        }
-
-        [Fact]
-        public void TestURI() {
-            ApiClient api = Init();
-            Assert.Equal(_defaultUri, api.URI);
-
-            // test alternate url as well as auto append trailing slash
-            string alternateUrl = "https://stage.rosette.com/rest/v1";
-            api.UseAlternateURL(alternateUrl);
-            Assert.Equal(alternateUrl + "/", api.URI);
-        }
-
-        [Fact]
-        public void TestConnections() {
-            ApiClient api = Init();
-            Assert.Equal(2, api.ConcurrentConnections);
-
-            api.AssignConcurrentConnections(6);
-            Assert.Equal(6, api.ConcurrentConnections);
-        }
-
-        [Fact]
-        public void TestValidCustomHeader() {
-            ApiClient api = Init();
-            Exception ex = Assert.Throws<ArgumentException>(() => api.AddCustomHeader("BogusHeader", "BogusValue"));
-
-            Assert.Contains(@"Custom header name must begin with 'X-RosetteAPI-'", ex.Message);
-        }
-
-        [Fact]
-        public void TestVersion() {
-            Assert.NotEmpty(ApiClient.Version);
-        }
-
-        [Fact]
-        public void TestTimeout() {
-            ApiClient api = Init();
-            Assert.Equal(300, api.Timeout);
-
-            api.AssignTimeout(15);
-            Assert.Equal(15, api.Timeout);
-        }
-
-        [Fact]
-        public void TestDebug() {
-            ApiClient api = Init();
-            Assert.False(api.Debug);
-
-            api.SetDebug();
-            Assert.True(api.Debug);
-        }
-
-        [Fact]
-        public void TestDefaultClient() {
-            ApiClient api = Init();
-
-            Assert.Equal(_defaultUri, api.Client.BaseAddress.AbsoluteUri);
-            var acceptHeader = new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json");
-            Assert.Contains(acceptHeader, api.Client.DefaultRequestHeaders.Accept);
-            foreach (string encodingType in new List<string>() { "gzip", "deflate" }) {
-                var encodingHeader = new System.Net.Http.Headers.StringWithQualityHeaderValue(encodingType);
-                Assert.Contains(encodingHeader, api.Client.DefaultRequestHeaders.AcceptEncoding);
-            }
-            Assert.Equal(api.Timeout, api.Client.Timeout.TotalSeconds);
-        }
-
+        Assert.Equal("Value cannot be null. (Parameter 'apiKey')", ex.Message);
     }
+
+    [Fact]
+    public void TestURI() {
+        ApiClient api = Init();
+        Assert.Equal(_defaultUri, api.URI);
+
+        // test alternate url as well as auto append trailing slash
+        string alternateUrl = "https://stage.rosette.com/rest/v1";
+        api.UseAlternateURL(alternateUrl);
+        Assert.Equal(alternateUrl + "/", api.URI);
+    }
+
+    [Fact]
+    public void TestConnections() {
+        ApiClient api = Init();
+        Assert.Equal(2, api.ConcurrentConnections);
+
+        api.AssignConcurrentConnections(6);
+        Assert.Equal(6, api.ConcurrentConnections);
+    }
+
+    [Fact]
+    public void TestValidCustomHeader() {
+        ApiClient api = Init();
+        Exception ex = Assert.Throws<ArgumentException>(() => api.AddCustomHeader("BogusHeader", "BogusValue"));
+
+        Assert.Contains(@"Custom header name must begin with 'X-RosetteAPI-'", ex.Message);
+    }
+
+    [Fact]
+    public void TestVersion() {
+        Assert.NotEmpty(ApiClient.Version);
+    }
+
+    [Fact]
+    public void TestTimeout() {
+        ApiClient api = Init();
+        Assert.Equal(300, api.Timeout);
+
+        api.AssignTimeout(15);
+        Assert.Equal(15, api.Timeout);
+    }
+
+    [Fact]
+    public void TestDebug() {
+        ApiClient api = Init();
+        Assert.False(api.Debug);
+
+        api.SetDebug();
+        Assert.True(api.Debug);
+    }
+
+    [Fact]
+    public void TestDefaultClient() {
+        ApiClient api = Init();
+
+        Assert.Equal(_defaultUri, api.Client.BaseAddress.AbsoluteUri);
+        var acceptHeader = new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json");
+        Assert.Contains(acceptHeader, api.Client.DefaultRequestHeaders.Accept);
+        foreach (string encodingType in new List<string>() { "gzip", "deflate" }) {
+            var encodingHeader = new System.Net.Http.Headers.StringWithQualityHeaderValue(encodingType);
+            Assert.Contains(encodingHeader, api.Client.DefaultRequestHeaders.AcceptEncoding);
+        }
+        Assert.Equal(api.Timeout, api.Client.Timeout.TotalSeconds);
+    }
+
 }

--- a/tests/ApiClientTests.cs
+++ b/tests/ApiClientTests.cs
@@ -1,24 +1,22 @@
-﻿using Rosette.Api.Endpoints;
-
-namespace Rosette.Api.Tests;
+﻿namespace Rosette.Api.Tests;
 
 public class ApiClientTests
 {
     private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/";
     private static readonly string _testKey = "testKey";
-
+        
     private static ApiClient Init() {
         return new ApiClient(_testKey);
     }
 
     [Fact]
-    public void TestKey() {
+    public void ApiKey_ReturnsProvidedKey_WhenInitialized() {
         ApiClient api = Init();
         Assert.Equal(_testKey, api.APIKey);
     }
 
     [Fact]
-    public void TestNullKey() {
+    public void Constructor_ThrowsArgumentNullException_WhenApiKeyIsNull() {
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
         string key = null;
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
@@ -30,7 +28,7 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestURI() {
+    public void URI_ReturnsDefaultAndAppendsTrailingSlash_WhenUsingAlternateUrl() {
         ApiClient api = Init();
         Assert.Equal(_defaultUri, api.URI);
 
@@ -41,7 +39,7 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestConnections() {
+    public void ConcurrentConnections_ReturnsCorrectValue_WhenDefaultAndAssigned() {
         ApiClient api = Init();
         Assert.Equal(2, api.ConcurrentConnections);
 
@@ -50,7 +48,7 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestValidCustomHeader() {
+    public void AddCustomHeader_ThrowsArgumentException_WhenHeaderNameIsInvalid() {
         ApiClient api = Init();
         Exception ex = Assert.Throws<ArgumentException>(() => api.AddCustomHeader("BogusHeader", "BogusValue"));
 
@@ -58,12 +56,12 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestVersion() {
+    public void Version_IsNotEmpty_Always() {
         Assert.NotEmpty(ApiClient.Version);
     }
 
     [Fact]
-    public void TestTimeout() {
+    public void Timeout_ReturnsCorrectValue_WhenDefaultAndAssigned() {
         ApiClient api = Init();
         Assert.Equal(300, api.Timeout);
 
@@ -72,7 +70,7 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestDebug() {
+    public void Debug_TogglesToTrue_WhenSetDebugCalled() {
         ApiClient api = Init();
         Assert.False(api.Debug);
 
@@ -81,7 +79,7 @@ public class ApiClientTests
     }
 
     [Fact]
-    public void TestDefaultClient() {
+    public void Client_HasCorrectDefaultConfiguration_WhenInitialized() {
         ApiClient api = Init();
 
         Assert.Equal(_defaultUri, api.Client.BaseAddress.AbsoluteUri);

--- a/tests/CategoriesTests.cs
+++ b/tests/CategoriesTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/CategoriesTests.cs
+++ b/tests/CategoriesTests.cs
@@ -5,40 +5,40 @@ namespace Rosette.Api.Tests;
 public class CategoriesTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         Categories c = new Categories("Sample text for categorization");
-        
+
         Assert.Equal("categories", c.Endpoint);
         Assert.Equal("Sample text for categorization", c.Content);
     }
 
     [Fact]
-    public void CheckWithLanguage()
+    public void SetLanguage_SetsLanguageProperty_WhenCalled()
     {
         Categories c = new Categories("Sample text")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", c.Language);
         Assert.Equal("Sample text", c.Content);
     }
 
     [Fact]
-    public void CheckWithGenre()
+    public void SetGenre_SetsGenreProperty_WhenCalled()
     {
         Categories c = new Categories("Sample text")
             .SetGenre("social-media");
-        
+
         Assert.Equal("", c.Genre);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingMultipleProperties()
     {
         Categories c = new Categories("Sample text")
             .SetLanguage("eng")
             .SetOption("customOption", "value");
-        
+
         Assert.Equal("eng", c.Language);
         Assert.Equal("value", c.Options["customOption"]);
     }

--- a/tests/CategoriesTests.cs
+++ b/tests/CategoriesTests.cs
@@ -1,46 +1,45 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class CategoriesTests
 {
-    public class CategoriesTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            Categories c = new Categories("Sample text for categorization");
-            
-            Assert.Equal("categories", c.Endpoint);
-            Assert.Equal("Sample text for categorization", c.Content);
-        }
+        Categories c = new Categories("Sample text for categorization");
+        
+        Assert.Equal("categories", c.Endpoint);
+        Assert.Equal("Sample text for categorization", c.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguage()
-        {
-            Categories c = new Categories("Sample text")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", c.Language);
-            Assert.Equal("Sample text", c.Content);
-        }
+    [Fact]
+    public void CheckWithLanguage()
+    {
+        Categories c = new Categories("Sample text")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", c.Language);
+        Assert.Equal("Sample text", c.Content);
+    }
 
-        [Fact]
-        public void CheckWithGenre()
-        {
-            Categories c = new Categories("Sample text")
-                .SetGenre("social-media");
-            
-            Assert.Equal("", c.Genre);
-        }
+    [Fact]
+    public void CheckWithGenre()
+    {
+        Categories c = new Categories("Sample text")
+            .SetGenre("social-media");
+        
+        Assert.Equal("", c.Genre);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            Categories c = new Categories("Sample text")
-                .SetLanguage("eng")
-                .SetOption("customOption", "value");
-            
-            Assert.Equal("eng", c.Language);
-            Assert.Equal("value", c.Options["customOption"]);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        Categories c = new Categories("Sample text")
+            .SetLanguage("eng")
+            .SetOption("customOption", "value");
+        
+        Assert.Equal("eng", c.Language);
+        Assert.Equal("value", c.Options["customOption"]);
     }
 }

--- a/tests/CategoriesTests.cs
+++ b/tests/CategoriesTests.cs
@@ -7,7 +7,7 @@ public class CategoriesTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
-        Categories c = new Categories("Sample text for categorization");
+        Categories c = new("Sample text for categorization");
 
         Assert.Equal("categories", c.Endpoint);
         Assert.Equal("Sample text for categorization", c.Content);

--- a/tests/ContentEndpointBaseTests.cs
+++ b/tests/ContentEndpointBaseTests.cs
@@ -1,4 +1,4 @@
-﻿using Rosette.Api.Endpoints.Core;
+﻿using Rosette.Api.Client.Endpoints.Core;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/ContentEndpointBaseTests.cs
+++ b/tests/ContentEndpointBaseTests.cs
@@ -82,16 +82,6 @@ public class ContentEndpointBaseTests
     }
 
     [Fact]
-    public void Content_AfterConstruction_ReturnsProvidedContent()
-    {
-        // Arrange & Act
-        var endpoint = new TestContentEndpoint("test content");
-
-        // Assert
-        Assert.Equal("test content", endpoint.Content);
-    }
-
-    [Fact]
     public void SetLanguage_ValidLanguageCode_SetsLanguage()
     {
         // Arrange
@@ -149,20 +139,6 @@ public class ContentEndpointBaseTests
     }
 
     [Fact]
-    public void Language_AfterSettingLanguage_ReturnsSetValue()
-    {
-        // Arrange
-        var endpoint = new TestContentEndpoint("content");
-        endpoint.SetLanguage("spa");
-
-        // Act
-        var language = endpoint.Language;
-
-        // Assert
-        Assert.Equal("spa", language);
-    }
-
-    [Fact]
     public void SetGenre_AnyValue_IsIgnoredAndReturnsInstance()
     {
         // Arrange
@@ -187,20 +163,6 @@ public class ContentEndpointBaseTests
 
         // Assert
         Assert.Equal(string.Empty, genre);
-    }
-
-    [Fact]
-    public void Genre_AfterSettingGenre_RemainsEmptyBecauseIgnored()
-    {
-        // Arrange
-        var endpoint = new TestContentEndpoint("content");
-        endpoint.SetGenre("news");
-
-        // Act
-        var genre = endpoint.Genre;
-
-        // Assert
-        Assert.Equal(string.Empty, genre); // Genre is ignored in ContentEndpointBase
     }
 
     [Fact]
@@ -261,20 +223,6 @@ public class ContentEndpointBaseTests
     }
 
     [Fact]
-    public void FileContentType_AfterSetting_ReturnsSetValue()
-    {
-        // Arrange
-        var endpoint = new TestContentEndpoint("content");
-        endpoint.SetFileContentType("application/json");
-
-        // Act
-        var contentType = endpoint.FileContentType;
-
-        // Assert
-        Assert.Equal("application/json", contentType);
-    }
-
-    [Fact]
     public void Filename_WithoutFileStream_ReturnsEmptyString()
     {
         // Arrange
@@ -309,38 +257,6 @@ public class ContentEndpointBaseTests
     }
 
     [Fact]
-    public void FluentAPI_ComplexChaining_MaintainsCorrectState()
-    {
-        // Arrange & Act
-        var endpoint = new TestContentEndpoint("original")
-            .SetLanguage("eng")
-            .SetContent("modified")
-            .SetFileContentType("text/html");
-
-        // Assert
-        Assert.Equal("modified", endpoint.Content);
-        Assert.Equal("eng", endpoint.Language);
-        Assert.Equal("text/html", endpoint.FileContentType);
-        Assert.Equal("test-endpoint", endpoint.Endpoint);
-    }
-
-    [Fact]
-    public void SetContent_MultipleTypes_HandlesAllContentTypes()
-    {
-        // Arrange
-        var endpoint = new TestContentEndpoint("initial");
-
-        // Act & Assert - String
-        endpoint.SetContent("string content");
-        Assert.Equal("string content", endpoint.Content);
-
-        // Act & Assert - Uri
-        var uri = new Uri("http://example.com");
-        endpoint.SetContent(uri);
-        Assert.Equal("http://example.com/", endpoint.Content.ToString());
-    }
-
-    [Fact]
     public void Constructor_WithFileStream_SetsContentAndFilename()
     {
         // Arrange
@@ -364,19 +280,6 @@ public class ContentEndpointBaseTests
                 File.Delete(tempFile);
             }
         }
-    }
-
-    [Fact]
-    public void SetLanguage_ISO6393Code_AcceptsThreeLetterCode()
-    {
-        // Arrange
-        var endpoint = new TestContentEndpoint("content");
-
-        // Act
-        endpoint.SetLanguage("zho"); // Chinese
-
-        // Assert
-        Assert.Equal("zho", endpoint.Language);
     }
 
     [Fact]

--- a/tests/ContentEndpointBaseTests.cs
+++ b/tests/ContentEndpointBaseTests.cs
@@ -1,0 +1,408 @@
+﻿using Rosette.Api.Endpoints.Core;
+
+namespace Rosette.Api.Tests;
+
+// Concrete test implementation of ContentEndpointBase for testing
+internal class TestContentEndpoint : ContentEndpointBase<TestContentEndpoint>
+{
+    public TestContentEndpoint(object content) : base("test-endpoint", content)
+    {
+    }
+}
+
+public class ContentEndpointBaseTests
+{
+    [Fact]
+    public void Constructor_ValidContent_SetsContentAndEndpoint()
+    {
+        // Arrange & Act
+        var endpoint = new TestContentEndpoint("test content");
+
+        // Assert
+        Assert.Equal("test-endpoint", endpoint.Endpoint);
+        Assert.Equal("test content", endpoint.Content);
+    }
+
+    [Fact]
+    public void Constructor_NullContent_ThrowsArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new TestContentEndpoint(null!));
+    }
+
+    [Fact]
+    public void Constructor_UriContent_SetsContentAsUriString()
+    {
+        // Arrange
+        var uri = new Uri("http://example.com/document");
+
+        // Act
+        var endpoint = new TestContentEndpoint(uri);
+
+        // Assert
+        Assert.Equal("http://example.com/document", endpoint.Content.ToString());
+    }
+
+    [Fact]
+    public void SetContent_ValidString_UpdatesContent()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("initial content");
+
+        // Act
+        var result = endpoint.SetContent("updated content");
+
+        // Assert
+        Assert.Equal("updated content", endpoint.Content);
+        Assert.Same(endpoint, result); // Verify fluent API
+    }
+
+    [Fact]
+    public void SetContent_NullContent_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("initial content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => endpoint.SetContent(null!));
+    }
+
+    [Fact]
+    public void SetContent_Uri_UpdatesContentToUriString()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("initial content");
+        var uri = new Uri("http://example.com/new");
+
+        // Act
+        endpoint.SetContent(uri);
+
+        // Assert
+        Assert.Equal("http://example.com/new", endpoint.Content.ToString());
+    }
+
+    [Fact]
+    public void Content_AfterConstruction_ReturnsProvidedContent()
+    {
+        // Arrange & Act
+        var endpoint = new TestContentEndpoint("test content");
+
+        // Assert
+        Assert.Equal("test content", endpoint.Content);
+    }
+
+    [Fact]
+    public void SetLanguage_ValidLanguageCode_SetsLanguage()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var result = endpoint.SetLanguage("eng");
+
+        // Assert
+        Assert.Equal("eng", endpoint.Language);
+        Assert.Same(endpoint, result); // Verify fluent API
+    }
+
+    [Fact]
+    public void SetLanguage_NullLanguage_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => endpoint.SetLanguage(null!));
+    }
+
+    [Fact]
+    public void SetLanguage_EmptyLanguage_ThrowsArgumentException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => endpoint.SetLanguage(string.Empty));
+    }
+
+    [Fact]
+    public void SetLanguage_WhitespaceLanguage_ThrowsArgumentException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => endpoint.SetLanguage("   "));
+    }
+
+    [Fact]
+    public void Language_WithoutSettingLanguage_ReturnsEmptyString()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var language = endpoint.Language;
+
+        // Assert
+        Assert.Equal(string.Empty, language);
+    }
+
+    [Fact]
+    public void Language_AfterSettingLanguage_ReturnsSetValue()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+        endpoint.SetLanguage("spa");
+
+        // Act
+        var language = endpoint.Language;
+
+        // Assert
+        Assert.Equal("spa", language);
+    }
+
+    [Fact]
+    public void SetGenre_AnyValue_IsIgnoredAndReturnsInstance()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var result = endpoint.SetGenre("social-media");
+
+        // Assert
+        Assert.Same(endpoint, result); // Verify fluent API
+        Assert.Equal(string.Empty, endpoint.Genre); // Genre should remain empty
+    }
+
+    [Fact]
+    public void Genre_WithoutSettingGenre_ReturnsEmptyString()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var genre = endpoint.Genre;
+
+        // Assert
+        Assert.Equal(string.Empty, genre);
+    }
+
+    [Fact]
+    public void Genre_AfterSettingGenre_RemainsEmptyBecauseIgnored()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+        endpoint.SetGenre("news");
+
+        // Act
+        var genre = endpoint.Genre;
+
+        // Assert
+        Assert.Equal(string.Empty, genre); // Genre is ignored in ContentEndpointBase
+    }
+
+    [Fact]
+    public void SetFileContentType_ValidContentType_SetsFileContentType()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var result = endpoint.SetFileContentType("application/pdf");
+
+        // Assert
+        Assert.Equal("application/pdf", endpoint.FileContentType);
+        Assert.Same(endpoint, result); // Verify fluent API
+    }
+
+    [Fact]
+    public void SetFileContentType_NullContentType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => endpoint.SetFileContentType(null!));
+    }
+
+    [Fact]
+    public void SetFileContentType_EmptyContentType_ThrowsArgumentException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => endpoint.SetFileContentType(string.Empty));
+    }
+
+    [Fact]
+    public void SetFileContentType_WhitespaceContentType_ThrowsArgumentException()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => endpoint.SetFileContentType("   "));
+    }
+
+    [Fact]
+    public void FileContentType_Default_ReturnsTextPlain()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var contentType = endpoint.FileContentType;
+
+        // Assert
+        Assert.Equal("text/plain", contentType); // Default from EndpointExecutor
+    }
+
+    [Fact]
+    public void FileContentType_AfterSetting_ReturnsSetValue()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+        endpoint.SetFileContentType("application/json");
+
+        // Act
+        var contentType = endpoint.FileContentType;
+
+        // Assert
+        Assert.Equal("application/json", contentType);
+    }
+
+    [Fact]
+    public void Filename_WithoutFileStream_ReturnsEmptyString()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        var filename = endpoint.Filename;
+
+        // Assert
+        Assert.Equal(string.Empty, filename);
+    }
+
+    [Fact]
+    public void FluentAPI_ChainMultipleMethods_AllSettersReturnSameInstance()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("initial content");
+
+        // Act
+        var result = endpoint
+            .SetContent("updated content")
+            .SetLanguage("eng")
+            .SetGenre("news")
+            .SetFileContentType("application/json");
+
+        // Assert
+        Assert.Same(endpoint, result);
+        Assert.Equal("updated content", endpoint.Content);
+        Assert.Equal("eng", endpoint.Language);
+        Assert.Equal(string.Empty, endpoint.Genre); // Genre is ignored
+        Assert.Equal("application/json", endpoint.FileContentType);
+    }
+
+    [Fact]
+    public void FluentAPI_ComplexChaining_MaintainsCorrectState()
+    {
+        // Arrange & Act
+        var endpoint = new TestContentEndpoint("original")
+            .SetLanguage("eng")
+            .SetContent("modified")
+            .SetFileContentType("text/html");
+
+        // Assert
+        Assert.Equal("modified", endpoint.Content);
+        Assert.Equal("eng", endpoint.Language);
+        Assert.Equal("text/html", endpoint.FileContentType);
+        Assert.Equal("test-endpoint", endpoint.Endpoint);
+    }
+
+    [Fact]
+    public void SetContent_MultipleTypes_HandlesAllContentTypes()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("initial");
+
+        // Act & Assert - String
+        endpoint.SetContent("string content");
+        Assert.Equal("string content", endpoint.Content);
+
+        // Act & Assert - Uri
+        var uri = new Uri("http://example.com");
+        endpoint.SetContent(uri);
+        Assert.Equal("http://example.com/", endpoint.Content.ToString());
+    }
+
+    [Fact]
+    public void Constructor_WithFileStream_SetsContentAndFilename()
+    {
+        // Arrange
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "test data");
+            using var fileStream = new FileStream(tempFile, FileMode.Open, FileAccess.Read);
+
+            // Act
+            var endpoint = new TestContentEndpoint(fileStream);
+
+            // Assert
+            Assert.NotNull(endpoint.Content);
+            Assert.Equal(tempFile, endpoint.Filename);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [Fact]
+    public void SetLanguage_ISO6393Code_AcceptsThreeLetterCode()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        endpoint.SetLanguage("zho"); // Chinese
+
+        // Assert
+        Assert.Equal("zho", endpoint.Language);
+    }
+
+    [Fact]
+    public void Options_SetOption_CanSetCustomOptions()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        endpoint.SetOption("customKey", "customValue");
+
+        // Assert
+        Assert.True(endpoint.Options.ContainsKey("customKey"));
+        Assert.Equal("customValue", endpoint.Options["customKey"]);
+    }
+
+    [Fact]
+    public void UrlParameters_SetUrlParameter_CanSetQueryParameters()
+    {
+        // Arrange
+        var endpoint = new TestContentEndpoint("content");
+
+        // Act
+        endpoint.SetUrlParameter("output", "rosette");
+
+        // Assert
+        Assert.Equal("rosette", endpoint.UrlParameters["output"]);
+    }
+}

--- a/tests/EndpointBaseTests.cs
+++ b/tests/EndpointBaseTests.cs
@@ -1,54 +1,657 @@
+using RichardSzalay.MockHttp;
 using Rosette.Api.Endpoints;
-using Rosette.Api.Endpoints.Core;
+using Rosette.Api.Models;
+using System.Net;
 
-namespace Rosette.Api.Tests {
+namespace Rosette.Api.Tests
+{
     public class EndpointBaseTests
     {
+        private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/*";
 
+        [Fact]
+        public void Constructor_ValidEndpoint_SetsEndpointName()
+        {
+            // Arrange & Act
+            var endpoint = new Entities("test content");
 
-        private static ApiClient Init() {
-            return new ApiClient("testkey");
+            // Assert
+            Assert.Equal("entities", endpoint.Endpoint);
         }
 
         [Fact]
-        public void CheckEndpoint() {
-            EndpointBase<Entities> ec = new EndpointBase<Entities>("foo");
-            Assert.Equal("foo", ec.Endpoint);
+        public void Options_InitialState_IsEmpty()
+        {
+            // Arrange & Act
+            var endpoint = new Entities("foo");
+
+            // Assert
+            Assert.Empty(endpoint.Options);
         }
 
+        [Fact]
+        public void Params_InitialState_IsNotEmpty()
+        {
+            // Arrange & Act
+            var endpoint = new Entities("foo");
 
+            // Assert
+            Assert.NotEmpty(endpoint.Params);
+        }
 
         [Fact]
-        public void CheckOptions() {
-            Entities e = new Entities("foo").SetOption("test", "value");
+        public void UrlParameters_InitialState_IsEmpty()
+        {
+            // Arrange & Act
+            var endpoint = new Entities("foo");
 
+            // Assert
+            Assert.Empty(endpoint.UrlParameters);
+        }
+
+        [Fact]
+        public void SetOption_ValidOption_AddsToOptions()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            e.SetOption("test", "value");
+
+            // Assert
             Assert.Equal("value", e.Options["test"]);
+        }
 
+        [Fact]
+        public void SetOption_MultipleOptions_AddsAllOptions()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            e.SetOption("test", "value");
             e.SetOption("test2", "value2");
 
+            // Assert
+            Assert.Equal("value", e.Options["test"]);
             Assert.Equal("value2", e.Options["test2"]);
-
-            e.RemoveOption("value");
-
-            Assert.True(!e.Options.ContainsKey("value"));
-
-            e.ClearOptions();
-
-            Assert.True(e.Options.Count == 0);
         }
 
         [Fact]
-        public void CheckUrlParameters() {
-            Entities e = new Entities("foo").SetUrlParameter("test", "value");
+        public void SetOption_NullOptionName_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
 
-            Assert.Equal("value", e.UrlParameters["test"]);
-
-            e.RemoveUrlParameter("test");
-
-            Assert.True(e.UrlParameters.Count == 0);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.SetOption(null!, "value"));
         }
 
+        [Fact]
+        public void SetOption_EmptyOptionName_ThrowsArgumentException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
 
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => e.SetOption(string.Empty, "value"));
+        }
 
+        [Fact]
+        public void SetOption_NullOptionValue_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.SetOption("test", null!));
+        }
+
+        [Fact]
+        public void SetOption_ReturnsInstance_ForFluentAPI()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            var result = e.SetOption("test", "value");
+
+            // Assert
+            Assert.Same(e, result);
+        }
+
+        [Fact]
+        public void RemoveOption_ExistingOption_RemovesOption()
+        {
+            // Arrange
+            Entities e = new Entities("foo")
+                .SetOption("test", "value");
+
+            // Act
+            e.RemoveOption("test");
+
+            // Assert
+            Assert.False(e.Options.ContainsKey("test"));
+        }
+
+        [Fact]
+        public void RemoveOption_NonExistingOption_DoesNotThrow()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            var exception = Record.Exception(() => e.RemoveOption("nonexistent"));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void RemoveOption_NullKey_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.RemoveOption(null!));
+        }
+
+        [Fact]
+        public void RemoveOption_ReturnsInstance_ForFluentAPI()
+        {
+            // Arrange
+            Entities e = new Entities("foo")
+                .SetOption("test", "value");
+
+            // Act
+            var result = e.RemoveOption("test");
+
+            // Assert
+            Assert.Same(e, result);
+        }
+
+        [Fact]
+        public void ClearOptions_WithOptions_RemovesAllOptions()
+        {
+            // Arrange
+            Entities e = new Entities("foo")
+                .SetOption("test1", "value1")
+                .SetOption("test2", "value2");
+
+            // Act
+            e.ClearOptions();
+
+            // Assert
+            Assert.Empty(e.Options);
+        }
+
+        [Fact]
+        public void ClearOptions_ReturnsInstance_ForFluentAPI()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            var result = e.ClearOptions();
+
+            // Assert
+            Assert.Same(e, result);
+        }
+
+        [Fact]
+        public void SetUrlParameter_ValidParameter_AddsToUrlParameters()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            e.SetUrlParameter("test", "value");
+
+            // Assert
+            Assert.Equal("value", e.UrlParameters["test"]);
+        }
+
+        [Fact]
+        public void SetUrlParameter_NullKey_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.SetUrlParameter(null!, "value"));
+        }
+
+        [Fact]
+        public void SetUrlParameter_NullValue_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.SetUrlParameter("key", null!));
+        }
+
+        [Fact]
+        public void SetUrlParameter_ReturnsInstance_ForFluentAPI()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act
+            var result = e.SetUrlParameter("test", "value");
+
+            // Assert
+            Assert.Same(e, result);
+        }
+
+        [Fact]
+        public void RemoveUrlParameter_ExistingParameter_RemovesParameter()
+        {
+            // Arrange
+            Entities e = new Entities("foo")
+                .SetUrlParameter("test", "value");
+
+            // Act
+            e.RemoveUrlParameter("test");
+
+            // Assert
+            Assert.Empty(e.UrlParameters);
+        }
+
+        [Fact]
+        public void RemoveUrlParameter_NullKey_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Entities e = new Entities("foo");
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => e.RemoveUrlParameter(null!));
+        }
+
+        [Fact]
+        public void RemoveUrlParameter_ReturnsInstance_ForFluentAPI()
+        {
+            // Arrange
+            Entities e = new Entities("foo")
+                .SetUrlParameter("test", "value");
+
+            // Act
+            var result = e.RemoveUrlParameter("test");
+
+            // Assert
+            Assert.Same(e, result);
+        }
+
+        [Fact]
+        public void FluentAPI_ChainMultipleMethods_AllSettersReturnSameInstance()
+        {
+            // Arrange & Act
+            var endpoint = new Entities("content")
+                .SetOption("opt1", "val1")
+                .SetOption("opt2", "val2")
+                .SetUrlParameter("param", "value")
+                .SetLanguage("eng");
+
+            // Assert
+            Assert.Equal("val1", endpoint.Options["opt1"]);
+            Assert.Equal("val2", endpoint.Options["opt2"]);
+            Assert.Equal("value", endpoint.UrlParameters["param"]);
+            Assert.Equal("eng", endpoint.Language);
+        }
+
+        [Fact]
+        public void Call_ValidEndpoint_ReturnsResponse()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act
+            Response result = endpoint.Call(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result.Content);
+        }
+
+        #region Async Tests
+
+        [Fact]
+        public async Task CallAsync_ValidEndpoint_ReturnsResponse()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result.Content);
+        }
+
+        [Fact]
+        public async Task CallAsync_WithCancellationToken_ReturnsResponse()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+            using var cts = new CancellationTokenSource();
+
+            // Act
+            Response result = await endpoint.CallAsync(api, cts.Token);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result.Content);
+        }
+
+        [Fact]
+        public async Task CallAsync_CancelledToken_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(async () =>
+                {
+                    await Task.Delay(100);
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"test\": \"OK\"}")
+                    };
+                });
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+            var cts = new CancellationTokenSource();
+            cts.Cancel(); // Cancel immediately
+
+            // Act & Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                async () => await endpoint.CallAsync(api, cts.Token));
+        }
+
+        [Fact]
+        public async Task CallAsync_WithTimeout_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(async () =>
+                {
+                    await Task.Delay(5000); // 5 second delay
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"test\": \"OK\"}")
+                    };
+                });
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)); // 100ms timeout
+
+            // Act & Assert
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await endpoint.CallAsync(api, cts.Token));
+        }
+
+        [Fact]
+        public async Task CallAsync_WithOptions_SendsOptionsToServer()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content")
+                .SetOption("linkEntities", true);
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.True((bool)endpoint.Options["linkEntities"]);
+        }
+
+        [Fact]
+        public async Task CallAsync_WithUrlParameters_AppendsQueryString()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.rosette.com/rest/v1/entities?output=rosette")
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content")
+                .SetUrlParameter("output", "rosette");
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("rosette", endpoint.UrlParameters["output"]);
+        }
+
+        [Fact]
+        public async Task CallAsync_ErrorResponse_ThrowsHttpRequestException()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{\"message\": \"Bad Request\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(
+                async () => await endpoint.CallAsync(api));
+        }
+
+        [Fact]
+        public async Task CallAsync_NotFoundResponse_ThrowsHttpRequestException()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.NotFound, "application/json", "{\"message\": \"Not Found\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(
+                async () => await endpoint.CallAsync(api));
+        }
+
+        [Fact]
+        public async Task CallAsync_UnauthorizedResponse_ThrowsHttpRequestException()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.Unauthorized, "application/json", "{\"message\": \"Unauthorized\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(
+                async () => await endpoint.CallAsync(api));
+        }
+
+        [Fact]
+        public async Task CallAsync_WithLanguage_SendsLanguageParameter()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content")
+                .SetLanguage("eng");
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("eng", endpoint.Language);
+        }
+
+        [Fact]
+        public async Task CallAsync_MultipleCallsToSameEndpoint_EachReturnsResponse()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content");
+
+            // Act
+            Response result1 = await endpoint.CallAsync(api);
+            Response result2 = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result1.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, result2.StatusCode);
+            Assert.NotSame(result1, result2); // Different instances
+        }
+
+        [Fact]
+        public async Task CallAsync_WithFluentChaining_AllSettingsApplied()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.rosette.com/rest/v1/entities?output=rosette")
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint = new Entities("test content")
+                .SetLanguage("eng")
+                .SetOption("linkEntities", true)
+                .SetUrlParameter("output", "rosette");
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("eng", endpoint.Language);
+            Assert.True((bool)endpoint.Options["linkEntities"]);
+            Assert.Equal("rosette", endpoint.UrlParameters["output"]);
+        }
+
+        [Fact]
+        public async Task CallAsync_ConcurrentCalls_BothComplete()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(_defaultUri)
+                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Entities endpoint1 = new Entities("content1");
+            Entities endpoint2 = new Entities("content2");
+
+            // Act
+            var task1 = endpoint1.CallAsync(api);
+            var task2 = endpoint2.CallAsync(api);
+            await Task.WhenAll(task1, task2);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, task1.Result.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, task2.Result.StatusCode);
+        }
+
+        [Fact]
+        public async Task CallAsync_InfoEndpoint_UsesGetCall()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.rosette.com/rest/v1/info")
+                .Respond(HttpStatusCode.OK, "application/json", "{\"name\": \"Rosette API\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Info endpoint = new Info();
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result.Content);
+        }
+
+        [Fact]
+        public async Task CallAsync_PingEndpoint_UsesGetCall()
+        {
+            // Arrange
+            ApiClient api = new ApiClient("testkey");
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("https://api.rosette.com/rest/v1/ping")
+                .Respond(HttpStatusCode.OK, "application/json", "{\"message\": \"pong\"}");
+            var client = mockHttp.ToHttpClient();
+            api.AssignClient(client);
+
+            Ping endpoint = new Ping();
+
+            // Act
+            Response result = await endpoint.CallAsync(api);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+            Assert.NotNull(result.Content);
+        }
+
+        #endregion
     }
 }

--- a/tests/EndpointBaseTests.cs
+++ b/tests/EndpointBaseTests.cs
@@ -8,7 +8,7 @@ namespace Rosette.Api.Tests
 {
     public class EndpointBaseTests
     {
-        private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/*";
+        private static readonly string _defaultUri = "https://analytics.babelstreet.com/rest/v1/*";
 
         [Fact]
         public void Constructor_ValidEndpoint_SetsEndpointName()
@@ -437,7 +437,6 @@ namespace Rosette.Api.Tests
 
             // Assert
             Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-            Assert.True((bool)endpoint.Options["linkEntities"]);
         }
 
         [Fact]
@@ -446,7 +445,7 @@ namespace Rosette.Api.Tests
             // Arrange
             ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When("https://api.rosette.com/rest/v1/entities?output=rosette")
+            mockHttp.When("https://analytics.babelstreet.com/rest/v1/entities?output=rosette")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
@@ -459,7 +458,6 @@ namespace Rosette.Api.Tests
 
             // Assert
             Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-            Assert.Equal("rosette", endpoint.UrlParameters["output"]);
         }
 
         [Fact]
@@ -535,7 +533,6 @@ namespace Rosette.Api.Tests
 
             // Assert
             Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-            Assert.Equal("eng", endpoint.Language);
         }
 
         [Fact]
@@ -591,7 +588,7 @@ namespace Rosette.Api.Tests
             // Arrange
             ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When("https://api.rosette.com/rest/v1/info")
+            mockHttp.When("https://analytics.babelstreet.com/rest/v1/info")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"name\": \"Rosette API\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
@@ -612,7 +609,7 @@ namespace Rosette.Api.Tests
             // Arrange
             ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When("https://api.rosette.com/rest/v1/ping")
+            mockHttp.When("https://analytics.babelstreet.com/rest/v1/ping")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"message\": \"pong\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);

--- a/tests/EndpointBaseTests.cs
+++ b/tests/EndpointBaseTests.cs
@@ -603,11 +603,11 @@ namespace Rosette.Api.Tests
             // Act
             var task1 = endpoint1.CallAsync(api);
             var task2 = endpoint2.CallAsync(api);
-            await Task.WhenAll(task1, task2);
+            var results = await Task.WhenAll(task1, task2);
 
             // Assert
-            Assert.Equal((int)HttpStatusCode.OK, task1.Result.StatusCode);
-            Assert.Equal((int)HttpStatusCode.OK, task2.Result.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, results[0].StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, results[1].StatusCode);
         }
 
         [Fact]

--- a/tests/EndpointBaseTests.cs
+++ b/tests/EndpointBaseTests.cs
@@ -54,7 +54,7 @@ namespace Rosette.Api.Tests
         public void SetOption_ValidOption_AddsToOptions()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             e.SetOption("test", "value");
@@ -67,7 +67,7 @@ namespace Rosette.Api.Tests
         public void SetOption_MultipleOptions_AddsAllOptions()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             e.SetOption("test", "value");
@@ -82,7 +82,7 @@ namespace Rosette.Api.Tests
         public void SetOption_NullOptionName_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.SetOption(null!, "value"));
@@ -92,7 +92,7 @@ namespace Rosette.Api.Tests
         public void SetOption_EmptyOptionName_ThrowsArgumentException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => e.SetOption(string.Empty, "value"));
@@ -102,7 +102,7 @@ namespace Rosette.Api.Tests
         public void SetOption_NullOptionValue_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.SetOption("test", null!));
@@ -112,7 +112,7 @@ namespace Rosette.Api.Tests
         public void SetOption_ReturnsInstance_ForFluentAPI()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             var result = e.SetOption("test", "value");
@@ -139,7 +139,7 @@ namespace Rosette.Api.Tests
         public void RemoveOption_NonExistingOption_DoesNotThrow()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             var exception = Record.Exception(() => e.RemoveOption("nonexistent"));
@@ -150,7 +150,7 @@ namespace Rosette.Api.Tests
         public void RemoveOption_NullKey_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.RemoveOption(null!));
@@ -189,7 +189,7 @@ namespace Rosette.Api.Tests
         public void ClearOptions_ReturnsInstance_ForFluentAPI()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             var result = e.ClearOptions();
@@ -202,7 +202,7 @@ namespace Rosette.Api.Tests
         public void SetUrlParameter_ValidParameter_AddsToUrlParameters()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             e.SetUrlParameter("test", "value");
@@ -215,7 +215,7 @@ namespace Rosette.Api.Tests
         public void SetUrlParameter_NullKey_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.SetUrlParameter(null!, "value"));
@@ -225,7 +225,7 @@ namespace Rosette.Api.Tests
         public void SetUrlParameter_NullValue_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.SetUrlParameter("key", null!));
@@ -235,7 +235,7 @@ namespace Rosette.Api.Tests
         public void SetUrlParameter_ReturnsInstance_ForFluentAPI()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act
             var result = e.SetUrlParameter("test", "value");
@@ -262,7 +262,7 @@ namespace Rosette.Api.Tests
         public void RemoveUrlParameter_NullKey_ThrowsArgumentNullException()
         {
             // Arrange
-            Entities e = new Entities("foo");
+            Entities e = new("foo");
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => e.RemoveUrlParameter(null!));
@@ -303,14 +303,14 @@ namespace Rosette.Api.Tests
         public void Call_ValidEndpoint_ReturnsResponse()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act
             Response result = endpoint.Call(api);
@@ -326,14 +326,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_ValidEndpoint_ReturnsResponse()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act
             Response result = await endpoint.CallAsync(api);
@@ -347,14 +347,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_WithCancellationToken_ReturnsResponse()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
             using var cts = new CancellationTokenSource();
 
             // Act
@@ -369,7 +369,7 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_CancelledToken_ThrowsOperationCanceledException()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(async () =>
@@ -383,7 +383,7 @@ namespace Rosette.Api.Tests
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
             var cts = new CancellationTokenSource();
             cts.Cancel(); // Cancel immediately
 
@@ -396,7 +396,7 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_WithTimeout_ThrowsOperationCanceledException()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(async () =>
@@ -410,7 +410,7 @@ namespace Rosette.Api.Tests
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
             using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)); // 100ms timeout
 
             // Act & Assert
@@ -422,7 +422,7 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_WithOptions_SendsOptionsToServer()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -444,7 +444,7 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_WithUrlParameters_AppendsQueryString()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://api.rosette.com/rest/v1/entities?output=rosette")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -466,14 +466,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_ErrorResponse_ThrowsHttpRequestException()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.BadRequest, "application/json", "{\"message\": \"Bad Request\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act & Assert
             await Assert.ThrowsAsync<HttpRequestException>(
@@ -484,14 +484,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_NotFoundResponse_ThrowsHttpRequestException()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.NotFound, "application/json", "{\"message\": \"Not Found\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act & Assert
             await Assert.ThrowsAsync<HttpRequestException>(
@@ -502,14 +502,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_UnauthorizedResponse_ThrowsHttpRequestException()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.Unauthorized, "application/json", "{\"message\": \"Unauthorized\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act & Assert
             await Assert.ThrowsAsync<HttpRequestException>(
@@ -520,7 +520,7 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_WithLanguage_SendsLanguageParameter()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -542,14 +542,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_MultipleCallsToSameEndpoint_EachReturnsResponse()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint = new Entities("test content");
+            Entities endpoint = new("test content");
 
             // Act
             Response result1 = await endpoint.CallAsync(api);
@@ -562,44 +562,18 @@ namespace Rosette.Api.Tests
         }
 
         [Fact]
-        public async Task CallAsync_WithFluentChaining_AllSettingsApplied()
-        {
-            // Arrange
-            ApiClient api = new ApiClient("testkey");
-            var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When("https://api.rosette.com/rest/v1/entities?output=rosette")
-                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
-            var client = mockHttp.ToHttpClient();
-            api.AssignClient(client);
-
-            Entities endpoint = new Entities("test content")
-                .SetLanguage("eng")
-                .SetOption("linkEntities", true)
-                .SetUrlParameter("output", "rosette");
-
-            // Act
-            Response result = await endpoint.CallAsync(api);
-
-            // Assert
-            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-            Assert.Equal("eng", endpoint.Language);
-            Assert.True((bool)endpoint.Options["linkEntities"]);
-            Assert.Equal("rosette", endpoint.UrlParameters["output"]);
-        }
-
-        [Fact]
         public async Task CallAsync_ConcurrentCalls_BothComplete()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(_defaultUri)
                 .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Entities endpoint1 = new Entities("content1");
-            Entities endpoint2 = new Entities("content2");
+            Entities endpoint1 = new("content1");
+            Entities endpoint2 = new("content2");
 
             // Act
             var task1 = endpoint1.CallAsync(api);
@@ -615,14 +589,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_InfoEndpoint_UsesGetCall()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://api.rosette.com/rest/v1/info")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"name\": \"Rosette API\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Info endpoint = new Info();
+            Info endpoint = new();
 
             // Act
             Response result = await endpoint.CallAsync(api);
@@ -636,14 +610,14 @@ namespace Rosette.Api.Tests
         public async Task CallAsync_PingEndpoint_UsesGetCall()
         {
             // Arrange
-            ApiClient api = new ApiClient("testkey");
+            ApiClient api = new("testkey");
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When("https://api.rosette.com/rest/v1/ping")
                 .Respond(HttpStatusCode.OK, "application/json", "{\"message\": \"pong\"}");
             var client = mockHttp.ToHttpClient();
             api.AssignClient(client);
 
-            Ping endpoint = new Ping();
+            Ping endpoint = new();
 
             // Act
             Response result = await endpoint.CallAsync(api);

--- a/tests/EndpointBaseTests.cs
+++ b/tests/EndpointBaseTests.cs
@@ -1,6 +1,7 @@
 using RichardSzalay.MockHttp;
-using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+using Rosette.Api.Client;
+using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 using System.Net;
 
 namespace Rosette.Api.Tests

--- a/tests/EndpointExecutorTests.cs
+++ b/tests/EndpointExecutorTests.cs
@@ -23,7 +23,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Content_SetStringAndAddToParams_WhenAssigned() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         f.Content = "Sample Content";
         Assert.Equal("Sample Content", f.Content);
@@ -33,13 +33,13 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Endpoint_ReturnsProvidedValue_WhenInitialized() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Equal("test", f.Endpoint);
     }
 
     [Fact]
     public void Content_SetUriAndAddToParams_WhenAssignedUri() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         f.Content = new Uri("http://google.com");
         Assert.Equal("http://google.com/", f.Content);
@@ -49,7 +49,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Content_SetFileStreamAndFilename_WhenAssignedFileStream() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         var newFile = Path.GetTempFileName();
         using (FileStream fs = File.OpenRead(newFile)) {
@@ -63,7 +63,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Language_SetLanguage_WhenAssigned() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Language!);
         f.Language = "eng";
         Assert.Equal("eng", f.Language);
@@ -71,7 +71,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Genre_SetGenre_WhenAssigned() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Genre!);
         f.Genre = "social-media";
         Assert.Equal("social-media", f.Genre);
@@ -79,7 +79,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void FileContentType_SetContentType_WhenAssigned() {
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Assert.Equal("text/plain", f.FileContentType);
         f.FileContentType = "octet/stream";
         Assert.Equal("octet/stream", f.FileContentType);
@@ -87,7 +87,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void Parameters_SerializeCorrectly_WhenOptionsSet() {
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -95,10 +95,10 @@ public class EndpointExecutorTests
 
         api.AssignClient(client);
 
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
 
         _options["opt"] = true;
-        Dictionary<string, object> paramTest = new Dictionary<string, object>();
+        Dictionary<string, object> paramTest = new();
         paramTest["content"] = "Test Content";
         paramTest["options"] = _options;
 
@@ -109,7 +109,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void PostCall_ReturnsOKResponse_WhenCalledWithValidContent() {
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -117,7 +117,7 @@ public class EndpointExecutorTests
 
         api.AssignClient(client);
 
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         f.Content = "Test content";
         Response result = f.PostCall(api);
         Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
@@ -125,7 +125,7 @@ public class EndpointExecutorTests
 
     [Fact]
     public void GetCall_ReturnsOKResponse_WhenCalled() {
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -133,7 +133,7 @@ public class EndpointExecutorTests
 
         api.AssignClient(client);
 
-        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor f = new(_params, _options, _urlParameters, "test");
         Response result = f.GetCall(api);
         Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
     }
@@ -144,14 +144,14 @@ public class EndpointExecutorTests
     public async Task GetCallAsync_ValidRequest_ReturnsResponse()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
 
         // Act
         Response result = await executor.GetCallAsync(api);
@@ -165,14 +165,14 @@ public class EndpointExecutorTests
     public async Task GetCallAsync_WithCancellationToken_ReturnsResponse()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         using var cts = new CancellationTokenSource();
 
         // Act
@@ -186,7 +186,7 @@ public class EndpointExecutorTests
     public async Task GetCallAsync_CancelledToken_ThrowsOperationCanceledException()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(async () =>
@@ -200,7 +200,7 @@ public class EndpointExecutorTests
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         var cts = new CancellationTokenSource();
         cts.Cancel(); // Cancel immediately
 
@@ -213,14 +213,14 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_WithStringContent_ReturnsResponse()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
 
         // Act
@@ -235,14 +235,14 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_WithCancellationToken_ReturnsResponse()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
         using var cts = new CancellationTokenSource();
 
@@ -257,7 +257,7 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_CancelledToken_ThrowsOperationCanceledException()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(async () =>
@@ -271,7 +271,7 @@ public class EndpointExecutorTests
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
         var cts = new CancellationTokenSource();
         cts.Cancel();
@@ -282,39 +282,10 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public async Task PostCallAsync_WithOptions_SerializesCorrectly()
-    {
-        // Arrange
-        ApiClient api = new ApiClient("testkey");
-        var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When(_defaultUri)
-            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
-        var client = mockHttp.ToHttpClient();
-        api.AssignClient(client);
-
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
-        _options["opt"] = true;
-        executor.Content = "Test Content";
-
-        Dictionary<string, object> expectedParams = new Dictionary<string, object>
-        {
-            ["content"] = "Test Content",
-            ["options"] = _options
-        };
-
-        // Act
-        Response result = await executor.PostCallAsync(api);
-
-        // Assert
-        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-        Assert.Equal(JsonSerializer.Serialize(expectedParams), JsonSerializer.Serialize(executor.Parameters));
-    }
-
-    [Fact]
     public async Task PostCallAsync_WithFileContent_SendsMultipart()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -328,7 +299,7 @@ public class EndpointExecutorTests
         {
             using (FileStream fs = File.OpenRead(tempFile))
             {
-                EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+                EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
                 executor.Content = fs;
 
                 // Act
@@ -352,7 +323,7 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_WithFileAndOptions_SendsMultipartWithRequest()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -366,7 +337,7 @@ public class EndpointExecutorTests
         {
             using (FileStream fs = File.OpenRead(tempFile))
             {
-                EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+                EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
                 _options["language"] = "eng";
                 executor.Content = fs;
 
@@ -391,7 +362,7 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_WithUrlParameters_AppendsQueryString()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When("https://api.rosette.com/rest/v1/test?output=rosette")
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
@@ -399,7 +370,7 @@ public class EndpointExecutorTests
         api.AssignClient(client);
 
         _urlParameters.Add("output", "rosette");
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
 
         // Act
@@ -413,7 +384,7 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_WithUnicodeContent_SendsUnescapedUnicode()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         string capturedRequest = string.Empty;
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
@@ -428,7 +399,7 @@ public class EndpointExecutorTests
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "北京大学 👍🏾"; // Chinese characters and emoji
 
         // Act
@@ -444,14 +415,14 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_ErrorResponse_ThrowsHttpRequestException()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.BadRequest, "application/json", "{\"message\": \"Bad Request\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
 
         // Act & Assert
@@ -463,14 +434,14 @@ public class EndpointExecutorTests
     public async Task GetCallAsync_ErrorResponse_ThrowsHttpRequestException()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(HttpStatusCode.NotFound, "application/json", "{\"message\": \"Not Found\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
 
         // Act & Assert
         await Assert.ThrowsAsync<HttpRequestException>(
@@ -481,7 +452,7 @@ public class EndpointExecutorTests
     public async Task PostCallAsync_TimeoutWithCancellation_ThrowsOperationCanceledException()
     {
         // Arrange
-        ApiClient api = new ApiClient("testkey");
+        ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
             .Respond(async () =>
@@ -495,7 +466,7 @@ public class EndpointExecutorTests
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);
 
-        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        EndpointExecutor executor = new(_params, _options, _urlParameters, "test");
         executor.Content = "Test content";
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)); // 100ms timeout
 

--- a/tests/EndpointExecutorTests.cs
+++ b/tests/EndpointExecutorTests.cs
@@ -2,8 +2,9 @@
 using System.Collections.Specialized;
 using System.Net;
 using System.Text.Json;
-using Rosette.Api.Endpoints.Core;
-using Rosette.Api.Models;
+using Rosette.Api.Client.Endpoints.Core;
+using Rosette.Api.Client.Models;
+using Rosette.Api.Client;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/EndpointExecutorTests.cs
+++ b/tests/EndpointExecutorTests.cs
@@ -5,136 +5,503 @@ using System.Text.Json;
 using Rosette.Api.Endpoints.Core;
 using Rosette.Api.Models;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class EndpointExecutorTests
 {
-    public class EndpointExecutorTests
-    {
-        private readonly Dictionary<string, object> _params;
-        private readonly Dictionary<string, object> _options;
-        private readonly NameValueCollection _urlParameters;
-        private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/*";
+    private readonly Dictionary<string, object> _params;
+    private readonly Dictionary<string, object> _options;
+    private readonly NameValueCollection _urlParameters;
+    private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/*";
 
-        public EndpointExecutorTests() {
-            _params = new Dictionary<string, object>();
-            _options = new Dictionary<string, object>();
-            _urlParameters = new NameValueCollection();
-        }
+    public EndpointExecutorTests() {
+        _params = new Dictionary<string, object>();
+        _options = new Dictionary<string, object>();
+        _urlParameters = new NameValueCollection();
+    }
 
-        [Fact]
-        public void CheckContent() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+    [Fact]
+    public void CheckContent() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Empty(f.Content.ToString()!);
+        f.Content = "Sample Content";
+        Assert.Equal("Sample Content", f.Content);
+        Assert.True(_params.ContainsKey("content"));
+        Assert.False(_params.ContainsKey("contenturi"));
+    }
+
+    [Fact]
+    public void CheckEndpoint() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Equal("test", f.Endpoint);
+    }
+
+    [Fact]
+    public void CheckContentUri() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Empty(f.Content.ToString()!);
+        f.Content = new Uri("http://google.com");
+        Assert.Equal("http://google.com/", f.Content);
+        Assert.True(_params.ContainsKey("contenturi"));
+        Assert.False(_params.ContainsKey("content"));
+    }
+
+    [Fact]
+    public void CheckFilename() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Empty(f.Content.ToString()!);
+        var newFile = Path.GetTempFileName();
+        using (FileStream fs = File.OpenRead(newFile)) {
+            f.Content = fs;
+            Assert.Equal(newFile, f.Filename);
             Assert.Empty(f.Content.ToString()!);
-            f.Content = "Sample Content";
-            Assert.Equal("Sample Content", f.Content);
-            Assert.True(_params.ContainsKey("content"));
+            Assert.False(_params.ContainsKey("content"));
             Assert.False(_params.ContainsKey("contenturi"));
         }
+    }
 
-        [Fact]
-        public void CheckEndpoint() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Equal("test", f.Endpoint);
-        }
+    [Fact]
+    public void CheckLanguage() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Empty(f.Language!);
+        f.Language = "eng";
+        Assert.Equal("eng", f.Language);
+    }
 
-        [Fact]
-        public void CheckContentUri() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Empty(f.Content.ToString()!);
-            f.Content = new Uri("http://google.com");
-            Assert.Equal("http://google.com/", f.Content);
-            Assert.True(_params.ContainsKey("contenturi"));
-            Assert.False(_params.ContainsKey("content"));
-        }
+    [Fact]
+    public void CheckGenre() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Empty(f.Genre!);
+        f.Genre = "social-media";
+        Assert.Equal("social-media", f.Genre);
+    }
 
-        [Fact]
-        public void CheckFilename() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Empty(f.Content.ToString()!);
-            var newFile = Path.GetTempFileName();
-            using (FileStream fs = File.OpenRead(newFile)) {
-                f.Content = fs;
-                Assert.Equal(newFile, f.Filename);
-                Assert.Empty(f.Content.ToString()!);
-                Assert.False(_params.ContainsKey("content"));
-                Assert.False(_params.ContainsKey("contenturi"));
+    [Fact]
+    public void CheckFileContentType() {
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Assert.Equal("text/plain", f.FileContentType);
+        f.FileContentType = "octet/stream";
+        Assert.Equal("octet/stream", f.FileContentType);
+    }
+
+    [Fact]
+    public void TestParameterSerialization() {
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+
+        api.AssignClient(client);
+
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+
+        _options["opt"] = true;
+        Dictionary<string, object> paramTest = new Dictionary<string, object>();
+        paramTest["content"] = "Test Content";
+        paramTest["options"] = _options;
+
+        f.Content = "Test Content";
+        Response result = f.PostCall(api);
+        Assert.Equal(JsonSerializer.Serialize(paramTest), JsonSerializer.Serialize(f.Parameters));
+    }
+
+    [Fact]
+    public void TestPostCall() {
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+
+        api.AssignClient(client);
+
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        f.Content = "Test content";
+        Response result = f.PostCall(api);
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public void TestGetCall() {
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+
+        api.AssignClient(client);
+
+        EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        Response result = f.GetCall(api);
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+    }
+
+    #region Async Tests
+
+    [Fact]
+    public async Task GetCallAsync_ValidRequest_ReturnsResponse()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+
+        // Act
+        Response result = await executor.GetCallAsync(api);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(result.Content);
+    }
+
+    [Fact]
+    public async Task GetCallAsync_WithCancellationToken_ReturnsResponse()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        Response result = await executor.GetCallAsync(api, cts.Token);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCallAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(async () =>
+            {
+                await Task.Delay(100); // Simulate delay
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"test\": \"OK\"}")
+                };
+            });
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        var cts = new CancellationTokenSource();
+        cts.Cancel(); // Cancel immediately
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            async () => await executor.GetCallAsync(api, cts.Token));
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithStringContent_ReturnsResponse()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+
+        // Act
+        Response result = await executor.PostCallAsync(api);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(result.Content);
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithCancellationToken_ReturnsResponse()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        Response result = await executor.PostCallAsync(api, cts.Token);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostCallAsync_CancelledToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(async () =>
+            {
+                await Task.Delay(100);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"test\": \"OK\"}")
+                };
+            });
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            async () => await executor.PostCallAsync(api, cts.Token));
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithOptions_SerializesCorrectly()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        _options["opt"] = true;
+        executor.Content = "Test Content";
+
+        Dictionary<string, object> expectedParams = new Dictionary<string, object>
+        {
+            ["content"] = "Test Content",
+            ["options"] = _options
+        };
+
+        // Act
+        Response result = await executor.PostCallAsync(api);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(JsonSerializer.Serialize(expectedParams), JsonSerializer.Serialize(executor.Parameters));
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithFileContent_SendsMultipart()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "test file content");
+
+        try
+        {
+            using (FileStream fs = File.OpenRead(tempFile))
+            {
+                EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+                executor.Content = fs;
+
+                // Act
+                Response result = await executor.PostCallAsync(api);
+
+                // Assert
+                Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+                Assert.Equal(tempFile, executor.Filename);
             }
         }
-
-        [Fact]
-        public void CheckLanguage() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Empty(f.Language!);
-            f.Language = "eng";
-            Assert.Equal("eng", f.Language);
-        }
-
-        [Fact]
-        public void CheckGenre() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Empty(f.Genre!);
-            f.Genre = "social-media";
-            Assert.Equal("social-media", f.Genre);
-        }
-
-        [Fact]
-        public void CheckFileContentType() {
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Assert.Equal("text/plain", f.FileContentType);
-            f.FileContentType = "octet/stream";
-            Assert.Equal("octet/stream", f.FileContentType);
-        }
-
-        [Fact]
-        public void TestParameterSerialization() {
-            ApiClient api = new ApiClient("testkey");
-            var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When(_defaultUri)
-                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
-            var client = mockHttp.ToHttpClient();
-
-            api.AssignClient(client);
-
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-
-            _options["opt"] = true;
-            Dictionary<string, object> paramTest = new Dictionary<string, object>();
-            paramTest["content"] = "Test Content";
-            paramTest["options"] = _options;
-
-            f.Content = "Test Content";
-            Response result = f.PostCall(api);
-            Assert.Equal(JsonSerializer.Serialize(paramTest), JsonSerializer.Serialize(f.Parameters));
-        }
-
-        [Fact]
-        public void TestPostCall() {
-            ApiClient api = new ApiClient("testkey");
-            var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When(_defaultUri)
-                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
-            var client = mockHttp.ToHttpClient();
-
-            api.AssignClient(client);
-
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            f.Content = "Test content";
-            Response result = f.PostCall(api);
-            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
-        }
-
-        [Fact]
-        public void TestGetCall() {
-            ApiClient api = new ApiClient("testkey");
-            var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When(_defaultUri)
-                .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
-            var client = mockHttp.ToHttpClient();
-
-            api.AssignClient(client);
-
-            EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
-            Response result = f.GetCall(api);
-            Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
         }
     }
+
+    [Fact]
+    public async Task PostCallAsync_WithFileAndOptions_SendsMultipartWithRequest()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "test file content");
+
+        try
+        {
+            using (FileStream fs = File.OpenRead(tempFile))
+            {
+                EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+                _options["language"] = "eng";
+                executor.Content = fs;
+
+                // Act
+                Response result = await executor.PostCallAsync(api);
+
+                // Assert
+                Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+                Assert.True(_options.ContainsKey("language"));
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithUrlParameters_AppendsQueryString()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("https://api.rosette.com/rest/v1/test?output=rosette")
+            .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        _urlParameters.Add("output", "rosette");
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+
+        // Act
+        Response result = await executor.PostCallAsync(api);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostCallAsync_WithUnicodeContent_SendsUnescapedUnicode()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        string capturedRequest = string.Empty;
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(async (request) =>
+            {
+                capturedRequest = await request.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"test\": \"OK\"}")
+                };
+            });
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "北京大学 👍🏾"; // Chinese characters and emoji
+
+        // Act
+        Response result = await executor.PostCallAsync(api);
+
+        // Assert
+        Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+        // Verify that the request contains actual Unicode, not escape sequences
+        Assert.Contains("北京大学", capturedRequest);
+    }
+
+    [Fact]
+    public async Task PostCallAsync_ErrorResponse_ThrowsHttpRequestException()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.BadRequest, "application/json", "{\"message\": \"Bad Request\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await executor.PostCallAsync(api));
+    }
+
+    [Fact]
+    public async Task GetCallAsync_ErrorResponse_ThrowsHttpRequestException()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(HttpStatusCode.NotFound, "application/json", "{\"message\": \"Not Found\"}");
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await executor.GetCallAsync(api));
+    }
+
+    [Fact]
+    public async Task PostCallAsync_TimeoutWithCancellation_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        ApiClient api = new ApiClient("testkey");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(_defaultUri)
+            .Respond(async () =>
+            {
+                await Task.Delay(5000); // 5 second delay
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"test\": \"OK\"}")
+                };
+            });
+        var client = mockHttp.ToHttpClient();
+        api.AssignClient(client);
+
+        EndpointExecutor executor = new EndpointExecutor(_params, _options, _urlParameters, "test");
+        executor.Content = "Test content";
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)); // 100ms timeout
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await executor.PostCallAsync(api, cts.Token));
+    }
+
+    #endregion
 }

--- a/tests/EndpointExecutorTests.cs
+++ b/tests/EndpointExecutorTests.cs
@@ -21,7 +21,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckContent() {
+    public void Content_SetStringAndAddToParams_WhenAssigned() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         f.Content = "Sample Content";
@@ -31,13 +31,13 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckEndpoint() {
+    public void Endpoint_ReturnsProvidedValue_WhenInitialized() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Equal("test", f.Endpoint);
     }
 
     [Fact]
-    public void CheckContentUri() {
+    public void Content_SetUriAndAddToParams_WhenAssignedUri() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         f.Content = new Uri("http://google.com");
@@ -47,7 +47,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckFilename() {
+    public void Content_SetFileStreamAndFilename_WhenAssignedFileStream() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Content.ToString()!);
         var newFile = Path.GetTempFileName();
@@ -61,7 +61,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckLanguage() {
+    public void Language_SetLanguage_WhenAssigned() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Language!);
         f.Language = "eng";
@@ -69,7 +69,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckGenre() {
+    public void Genre_SetGenre_WhenAssigned() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Empty(f.Genre!);
         f.Genre = "social-media";
@@ -77,7 +77,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void CheckFileContentType() {
+    public void FileContentType_SetContentType_WhenAssigned() {
         EndpointExecutor f = new EndpointExecutor(_params, _options, _urlParameters, "test");
         Assert.Equal("text/plain", f.FileContentType);
         f.FileContentType = "octet/stream";
@@ -85,7 +85,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void TestParameterSerialization() {
+    public void Parameters_SerializeCorrectly_WhenOptionsSet() {
         ApiClient api = new ApiClient("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
@@ -107,7 +107,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void TestPostCall() {
+    public void PostCall_ReturnsOKResponse_WhenCalledWithValidContent() {
         ApiClient api = new ApiClient("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)
@@ -123,7 +123,7 @@ public class EndpointExecutorTests
     }
 
     [Fact]
-    public void TestGetCall() {
+    public void GetCall_ReturnsOKResponse_WhenCalled() {
         ApiClient api = new ApiClient("testkey");
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.When(_defaultUri)

--- a/tests/EndpointExecutorTests.cs
+++ b/tests/EndpointExecutorTests.cs
@@ -13,7 +13,7 @@ public class EndpointExecutorTests
     private readonly Dictionary<string, object> _params;
     private readonly Dictionary<string, object> _options;
     private readonly NameValueCollection _urlParameters;
-    private static readonly string _defaultUri = "https://api.rosette.com/rest/v1/*";
+    private static readonly string _defaultUri = "https://analytics.babelstreet.com/rest/v1/*";
 
     public EndpointExecutorTests() {
         _params = new Dictionary<string, object>();
@@ -364,7 +364,7 @@ public class EndpointExecutorTests
         // Arrange
         ApiClient api = new("testkey");
         var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When("https://api.rosette.com/rest/v1/test?output=rosette")
+        mockHttp.When("https://analytics.babelstreet.com/rest/v1/test?output=rosette")
             .Respond(HttpStatusCode.OK, "application/json", "{\"test\": \"OK\"}");
         var client = mockHttp.ToHttpClient();
         api.AssignClient(client);

--- a/tests/EntitiesTests.cs
+++ b/tests/EntitiesTests.cs
@@ -5,44 +5,44 @@ namespace Rosette.Api.Tests;
 public class EntitiesTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         string text = "Bill Murray will appear in new Ghostbusters film.";
         Entities e = new Entities(text);
-        
+
         Assert.Equal("entities", e.Endpoint);
         Assert.Equal(text, e.Content);
     }
 
     [Fact]
-    public void CheckWithLanguageAndGenre()
+    public void SetLanguageAndGenre_SetsProperties_WhenCalled()
     {
         Entities e = new Entities("Sample text")
             .SetLanguage("eng")
             .SetGenre("social-media");
-        
+
         Assert.Equal("eng", e.Language);
         Assert.Equal("", e.Genre);
     }
 
     [Fact]
-    public void CheckWithUrlParameter()
+    public void SetUrlParameter_AddsParameterToUrlParameters_WhenCalled()
     {
         Entities e = new Entities("Sample text")
             .SetUrlParameter("output", "rosette");
-        
+
         Assert.Equal("rosette", e.UrlParameters["output"]);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingMultipleProperties()
     {
         Entities e = new Entities("Apple announced a new iPhone.")
             .SetLanguage("eng")
             .SetGenre("news")
             .SetOption("linkEntities", true)
             .SetUrlParameter("output", "rosette");
-        
+
         Assert.Equal("eng", e.Language);
         Assert.True((bool)e.Options["linkEntities"]);
         Assert.Equal("rosette", e.UrlParameters["output"]);

--- a/tests/EntitiesTests.cs
+++ b/tests/EntitiesTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/EntitiesTests.cs
+++ b/tests/EntitiesTests.cs
@@ -1,51 +1,50 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class EntitiesTests
 {
-    public class EntitiesTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            string text = "Bill Murray will appear in new Ghostbusters film.";
-            Entities e = new Entities(text);
-            
-            Assert.Equal("entities", e.Endpoint);
-            Assert.Equal(text, e.Content);
-        }
+        string text = "Bill Murray will appear in new Ghostbusters film.";
+        Entities e = new Entities(text);
+        
+        Assert.Equal("entities", e.Endpoint);
+        Assert.Equal(text, e.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguageAndGenre()
-        {
-            Entities e = new Entities("Sample text")
-                .SetLanguage("eng")
-                .SetGenre("social-media");
-            
-            Assert.Equal("eng", e.Language);
-            Assert.Equal("", e.Genre);
-        }
+    [Fact]
+    public void CheckWithLanguageAndGenre()
+    {
+        Entities e = new Entities("Sample text")
+            .SetLanguage("eng")
+            .SetGenre("social-media");
+        
+        Assert.Equal("eng", e.Language);
+        Assert.Equal("", e.Genre);
+    }
 
-        [Fact]
-        public void CheckWithUrlParameter()
-        {
-            Entities e = new Entities("Sample text")
-                .SetUrlParameter("output", "rosette");
-            
-            Assert.Equal("rosette", e.UrlParameters["output"]);
-        }
+    [Fact]
+    public void CheckWithUrlParameter()
+    {
+        Entities e = new Entities("Sample text")
+            .SetUrlParameter("output", "rosette");
+        
+        Assert.Equal("rosette", e.UrlParameters["output"]);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            Entities e = new Entities("Apple announced a new iPhone.")
-                .SetLanguage("eng")
-                .SetGenre("news")
-                .SetOption("linkEntities", true)
-                .SetUrlParameter("output", "rosette");
-            
-            Assert.Equal("eng", e.Language);
-            Assert.True((bool)e.Options["linkEntities"]);
-            Assert.Equal("rosette", e.UrlParameters["output"]);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        Entities e = new Entities("Apple announced a new iPhone.")
+            .SetLanguage("eng")
+            .SetGenre("news")
+            .SetOption("linkEntities", true)
+            .SetUrlParameter("output", "rosette");
+        
+        Assert.Equal("eng", e.Language);
+        Assert.True((bool)e.Options["linkEntities"]);
+        Assert.Equal("rosette", e.UrlParameters["output"]);
     }
 }

--- a/tests/EntitiesTests.cs
+++ b/tests/EntitiesTests.cs
@@ -8,7 +8,7 @@ public class EntitiesTests
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         string text = "Bill Murray will appear in new Ghostbusters film.";
-        Entities e = new Entities(text);
+        Entities e = new(text);
 
         Assert.Equal("entities", e.Endpoint);
         Assert.Equal(text, e.Content);

--- a/tests/LanguageTests.cs
+++ b/tests/LanguageTests.cs
@@ -7,7 +7,7 @@ public class LanguageTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
-        Language l = new Language("Por favor Señorita, says the man.");
+        Language l = new("Por favor Señorita, says the man.");
 
         Assert.Equal("language", l.Endpoint);
         Assert.Equal("Por favor Señorita, says the man.", l.Content);
@@ -16,8 +16,8 @@ public class LanguageTests
     [Fact]
     public void Constructor_SetsContentFromUri_WhenCalledWithUri()
     {
-        Uri uri = new Uri("http://example.com");
-        Language l = new Language(uri);
+        Uri uri = new("http://example.com");
+        Language l = new(uri);
 
         Assert.Equal("http://example.com/", l.Content.ToString());
     }

--- a/tests/LanguageTests.cs
+++ b/tests/LanguageTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/LanguageTests.cs
+++ b/tests/LanguageTests.cs
@@ -1,43 +1,42 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class LanguageTests
 {
-    public class LanguageTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            Language l = new Language("Por favor Señorita, says the man.");
-            
-            Assert.Equal("language", l.Endpoint);
-            Assert.Equal("Por favor Señorita, says the man.", l.Content);
-        }
+        Language l = new Language("Por favor Señorita, says the man.");
+        
+        Assert.Equal("language", l.Endpoint);
+        Assert.Equal("Por favor Señorita, says the man.", l.Content);
+    }
 
-        [Fact]
-        public void CheckWithUri()
-        {
-            Uri uri = new Uri("http://example.com");
-            Language l = new Language(uri);
-            
-            Assert.Equal("http://example.com/", l.Content.ToString());
-        }
+    [Fact]
+    public void CheckWithUri()
+    {
+        Uri uri = new Uri("http://example.com");
+        Language l = new Language(uri);
+        
+        Assert.Equal("http://example.com/", l.Content.ToString());
+    }
 
-        [Fact]
-        public void CheckContentUpdate()
-        {
-            Language l = new Language("Original text")
-                .SetContent("Updated text");
-            
-            Assert.Equal("Updated text", l.Content);
-        }
+    [Fact]
+    public void CheckContentUpdate()
+    {
+        Language l = new Language("Original text")
+            .SetContent("Updated text");
+        
+        Assert.Equal("Updated text", l.Content);
+    }
 
-        [Fact]
-        public void CheckWithGenre()
-        {
-            Language l = new Language("Sample text")
-                .SetGenre("social-media");
-            
-            Assert.Equal("", l.Genre);
-        }
+    [Fact]
+    public void CheckWithGenre()
+    {
+        Language l = new Language("Sample text")
+            .SetGenre("social-media");
+        
+        Assert.Equal("", l.Genre);
     }
 }

--- a/tests/LanguageTests.cs
+++ b/tests/LanguageTests.cs
@@ -5,38 +5,38 @@ namespace Rosette.Api.Tests;
 public class LanguageTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         Language l = new Language("Por favor Señorita, says the man.");
-        
+
         Assert.Equal("language", l.Endpoint);
         Assert.Equal("Por favor Señorita, says the man.", l.Content);
     }
 
     [Fact]
-    public void CheckWithUri()
+    public void Constructor_SetsContentFromUri_WhenCalledWithUri()
     {
         Uri uri = new Uri("http://example.com");
         Language l = new Language(uri);
-        
+
         Assert.Equal("http://example.com/", l.Content.ToString());
     }
 
     [Fact]
-    public void CheckContentUpdate()
+    public void SetContent_UpdatesContent_WhenCalled()
     {
         Language l = new Language("Original text")
             .SetContent("Updated text");
-        
+
         Assert.Equal("Updated text", l.Content);
     }
 
     [Fact]
-    public void CheckWithGenre()
+    public void SetGenre_SetsGenreProperty_WhenCalled()
     {
         Language l = new Language("Sample text")
             .SetGenre("social-media");
-        
+
         Assert.Equal("", l.Genre);
     }
 }

--- a/tests/NameDeduplicationTests.cs
+++ b/tests/NameDeduplicationTests.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/NameDeduplicationTests.cs
+++ b/tests/NameDeduplicationTests.cs
@@ -6,7 +6,7 @@ namespace Rosette.Api.Tests;
 public class NameDeduplicationTests
 {
     [Fact]
-    public void CheckBasicUsage() {
+    public void Constructor_SetsNamesAndThreshold_WhenCalledWithNames() {
         List<Name> names = new List<Name> {
             new Name("foo"),
             new Name("bar")
@@ -17,7 +17,7 @@ public class NameDeduplicationTests
     }
 
     [Fact]
-    public void CheckProfileID() {
+    public void SetProfileID_SetsProfileID_WhenCalled() {
         List<Name> names = new List<Name> {
             new Name("foo"),
             new Name("bar")
@@ -28,7 +28,7 @@ public class NameDeduplicationTests
     }
 
     [Fact]
-    public void CheckThreshold() {
+    public void SetThreshold_SetsThreshold_WhenCalled() {
         List<Name> names = new List<Name> {
             new Name("foo"),
             new Name("bar")

--- a/tests/NameDeduplicationTests.cs
+++ b/tests/NameDeduplicationTests.cs
@@ -7,18 +7,20 @@ public class NameDeduplicationTests
 {
     [Fact]
     public void Constructor_SetsNamesAndThreshold_WhenCalledWithNames() {
-        List<Name> names = new List<Name> {
+        List<Name> names = new()
+        {
             new Name("foo"),
             new Name("bar")
         };
-        NameDeduplication n = new NameDeduplication(names);
+        NameDeduplication n = new(names);
         Assert.Equal(names, n.Names);
         Assert.Equal(0.75f, n.Threshold);
     }
 
     [Fact]
     public void SetProfileID_SetsProfileID_WhenCalled() {
-        List<Name> names = new List<Name> {
+        List<Name> names = new()
+        {
             new Name("foo"),
             new Name("bar")
         };
@@ -29,7 +31,8 @@ public class NameDeduplicationTests
 
     [Fact]
     public void SetThreshold_SetsThreshold_WhenCalled() {
-        List<Name> names = new List<Name> {
+        List<Name> names = new()
+        {
             new Name("foo"),
             new Name("bar")
         };

--- a/tests/NameDeduplicationTests.cs
+++ b/tests/NameDeduplicationTests.cs
@@ -1,41 +1,40 @@
 ﻿using Rosette.Api.Endpoints;
 using Rosette.Api.Models;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class NameDeduplicationTests
 {
-    public class NameDeduplicationTests
-    {
-        [Fact]
-        public void CheckBasicUsage() {
-            List<Name> names = new List<Name> {
-                new Name("foo"),
-                new Name("bar")
-            };
-            NameDeduplication n = new NameDeduplication(names);
-            Assert.Equal(names, n.Names);
-            Assert.Equal(0.75f, n.Threshold);
-        }
+    [Fact]
+    public void CheckBasicUsage() {
+        List<Name> names = new List<Name> {
+            new Name("foo"),
+            new Name("bar")
+        };
+        NameDeduplication n = new NameDeduplication(names);
+        Assert.Equal(names, n.Names);
+        Assert.Equal(0.75f, n.Threshold);
+    }
 
-        [Fact]
-        public void CheckProfileID() {
-            List<Name> names = new List<Name> {
-                new Name("foo"),
-                new Name("bar")
-            };
-            NameDeduplication n = new NameDeduplication(names).SetProfileID("profileid");
-            Assert.Equal(names, n.Names);
-            Assert.Equal("profileid", n.ProfileID);
-        }
+    [Fact]
+    public void CheckProfileID() {
+        List<Name> names = new List<Name> {
+            new Name("foo"),
+            new Name("bar")
+        };
+        NameDeduplication n = new NameDeduplication(names).SetProfileID("profileid");
+        Assert.Equal(names, n.Names);
+        Assert.Equal("profileid", n.ProfileID);
+    }
 
-        [Fact]
-        public void CheckThreshold() {
-            List<Name> names = new List<Name> {
-                new Name("foo"),
-                new Name("bar")
-            };
-            NameDeduplication n = new NameDeduplication(names).SetThreshold(0.8f);
-            Assert.Equal(names, n.Names);
-            Assert.Equal(0.8f, n.Threshold);
-        }
+    [Fact]
+    public void CheckThreshold() {
+        List<Name> names = new List<Name> {
+            new Name("foo"),
+            new Name("bar")
+        };
+        NameDeduplication n = new NameDeduplication(names).SetThreshold(0.8f);
+        Assert.Equal(names, n.Names);
+        Assert.Equal(0.8f, n.Threshold);
     }
 }

--- a/tests/NameSimilarityTests.cs
+++ b/tests/NameSimilarityTests.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/NameSimilarityTests.cs
+++ b/tests/NameSimilarityTests.cs
@@ -1,20 +1,19 @@
 ﻿using Rosette.Api.Endpoints;
 using Rosette.Api.Models;
 
-namespace Rosette.Api.Tests
-{
-    public class NameSimilarityTests
-    {
-        [Fact]
-        public void CheckForNull() {
-            var exception = Record.Exception(() => new NameSimilarity(null, null));
-            Assert.IsType<ArgumentNullException>(exception);
-            Assert.Equal("Value cannot be null. (Parameter 'name1')", exception.Message);
+namespace Rosette.Api.Tests;
 
-            Name rn = new Name("foo");
-            exception = Record.Exception(() => new NameSimilarity(rn, null));
-            Assert.IsType<ArgumentNullException>(exception);
-            Assert.Equal("Value cannot be null. (Parameter 'name2')", exception.Message);
-        }
+public class NameSimilarityTests
+{
+    [Fact]
+    public void CheckForNull() {
+        var exception = Record.Exception(() => new NameSimilarity(null, null));
+        Assert.IsType<ArgumentNullException>(exception);
+        Assert.Equal("Value cannot be null. (Parameter 'name1')", exception.Message);
+
+        Name rn = new Name("foo");
+        exception = Record.Exception(() => new NameSimilarity(rn, null));
+        Assert.IsType<ArgumentNullException>(exception);
+        Assert.Equal("Value cannot be null. (Parameter 'name2')", exception.Message);
     }
 }

--- a/tests/NameSimilarityTests.cs
+++ b/tests/NameSimilarityTests.cs
@@ -6,7 +6,7 @@ namespace Rosette.Api.Tests;
 public class NameSimilarityTests
 {
     [Fact]
-    public void CheckForNull() {
+    public void Constructor_ThrowsArgumentNullException_WhenNamesAreNull() {
         var exception = Record.Exception(() => new NameSimilarity(null, null));
         Assert.IsType<ArgumentNullException>(exception);
         Assert.Equal("Value cannot be null. (Parameter 'name1')", exception.Message);

--- a/tests/NameSimilarityTests.cs
+++ b/tests/NameSimilarityTests.cs
@@ -11,7 +11,7 @@ public class NameSimilarityTests
         Assert.IsType<ArgumentNullException>(exception);
         Assert.Equal("Value cannot be null. (Parameter 'name1')", exception.Message);
 
-        Name rn = new Name("foo");
+        Name rn = new("foo");
         exception = Record.Exception(() => new NameSimilarity(rn, null));
         Assert.IsType<ArgumentNullException>(exception);
         Assert.Equal("Value cannot be null. (Parameter 'name2')", exception.Message);

--- a/tests/NameTests.cs
+++ b/tests/NameTests.cs
@@ -5,7 +5,7 @@ namespace Rosette.Api.Tests;
 public class NameTests
 {
     [Fact]
-    public void CheckName() {
+    public void Constructor_SetsTextAndNullProperties_WhenCreatingName() {
         Name rn = new Name("foo");
         Assert.Equal("foo", rn.Text);
         Assert.Null(rn.EntityType);
@@ -15,28 +15,28 @@ public class NameTests
     }
 
     [Fact]
-    public void CheckWithEntityType() {
+    public void SetEntityType_SetsEntityType_WhenCalled() {
         Name rn = new Name("foo").SetEntityType("PERSON");
         Assert.Equal("foo", rn.Text);
         Assert.Equal("PERSON", rn.EntityType);
     }
 
     [Fact]
-    public void CheckWithLanguage() {
+    public void SetLanguage_SetsLanguage_WhenCalled() {
         Name rn = new Name("foo").SetLanguage("eng");
         Assert.Equal("foo", rn.Text);
         Assert.Equal("eng", rn.Language);
     }
 
     [Fact]
-    public void CheckWithScript() {
+    public void SetScript_SetsScript_WhenCalled() {
         Name rn = new Name("foo").SetScript("zho");
         Assert.Equal("foo", rn.Text);
         Assert.Equal("zho", rn.Script);
     }
 
     [Fact]
-    public void CheckWithGender()
+    public void SetGender_SetsGender_WhenCalled()
     {
         Name rn = new Name("foo").SetGender(GenderType.Female);
         Assert.Equal("foo", rn.Text);
@@ -44,7 +44,7 @@ public class NameTests
     }
 
     [Fact]
-    public void CheckAll() {
+    public void FluentAPI_SetsAllProperties_WhenChaining() {
         Name rn = new Name("foo")
             .SetEntityType("PERSON")
             .SetLanguage("eng")

--- a/tests/NameTests.cs
+++ b/tests/NameTests.cs
@@ -6,7 +6,7 @@ public class NameTests
 {
     [Fact]
     public void Constructor_SetsTextAndNullProperties_WhenCreatingName() {
-        Name rn = new Name("foo");
+        Name rn = new("foo");
         Assert.Equal("foo", rn.Text);
         Assert.Null(rn.EntityType);
         Assert.Null(rn.Language);

--- a/tests/NameTests.cs
+++ b/tests/NameTests.cs
@@ -1,60 +1,59 @@
 ﻿using Rosette.Api.Models;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class NameTests
 {
-    public class NameTests
+    [Fact]
+    public void CheckName() {
+        Name rn = new Name("foo");
+        Assert.Equal("foo", rn.Text);
+        Assert.Null(rn.EntityType);
+        Assert.Null(rn.Language);
+        Assert.Null(rn.Script);
+        Assert.Null(rn.Gender);
+    }
+
+    [Fact]
+    public void CheckWithEntityType() {
+        Name rn = new Name("foo").SetEntityType("PERSON");
+        Assert.Equal("foo", rn.Text);
+        Assert.Equal("PERSON", rn.EntityType);
+    }
+
+    [Fact]
+    public void CheckWithLanguage() {
+        Name rn = new Name("foo").SetLanguage("eng");
+        Assert.Equal("foo", rn.Text);
+        Assert.Equal("eng", rn.Language);
+    }
+
+    [Fact]
+    public void CheckWithScript() {
+        Name rn = new Name("foo").SetScript("zho");
+        Assert.Equal("foo", rn.Text);
+        Assert.Equal("zho", rn.Script);
+    }
+
+    [Fact]
+    public void CheckWithGender()
     {
-        [Fact]
-        public void CheckName() {
-            Name rn = new Name("foo");
-            Assert.Equal("foo", rn.Text);
-            Assert.Null(rn.EntityType);
-            Assert.Null(rn.Language);
-            Assert.Null(rn.Script);
-            Assert.Null(rn.Gender);
-        }
+        Name rn = new Name("foo").SetGender(GenderType.Female);
+        Assert.Equal("foo", rn.Text);
+        Assert.Equal(GenderType.Female, rn.Gender);
+    }
 
-        [Fact]
-        public void CheckWithEntityType() {
-            Name rn = new Name("foo").SetEntityType("PERSON");
-            Assert.Equal("foo", rn.Text);
-            Assert.Equal("PERSON", rn.EntityType);
-        }
-
-        [Fact]
-        public void CheckWithLanguage() {
-            Name rn = new Name("foo").SetLanguage("eng");
-            Assert.Equal("foo", rn.Text);
-            Assert.Equal("eng", rn.Language);
-        }
-
-        [Fact]
-        public void CheckWithScript() {
-            Name rn = new Name("foo").SetScript("zho");
-            Assert.Equal("foo", rn.Text);
-            Assert.Equal("zho", rn.Script);
-        }
-
-        [Fact]
-        public void CheckWithGender()
-        {
-            Name rn = new Name("foo").SetGender(GenderType.Female);
-            Assert.Equal("foo", rn.Text);
-            Assert.Equal(GenderType.Female, rn.Gender);
-        }
-
-        [Fact]
-        public void CheckAll() {
-            Name rn = new Name("foo")
-                .SetEntityType("PERSON")
-                .SetLanguage("eng")
-                .SetScript("zho")
-                .SetGender(GenderType.Male);
-            Assert.Equal("foo", rn.Text);
-            Assert.Equal("PERSON", rn.EntityType);
-            Assert.Equal("eng", rn.Language);
-            Assert.Equal("zho", rn.Script);
-            Assert.Equal(GenderType.Male, rn.Gender);
-        }
+    [Fact]
+    public void CheckAll() {
+        Name rn = new Name("foo")
+            .SetEntityType("PERSON")
+            .SetLanguage("eng")
+            .SetScript("zho")
+            .SetGender(GenderType.Male);
+        Assert.Equal("foo", rn.Text);
+        Assert.Equal("PERSON", rn.EntityType);
+        Assert.Equal("eng", rn.Language);
+        Assert.Equal("zho", rn.Script);
+        Assert.Equal(GenderType.Male, rn.Gender);
     }
 }

--- a/tests/NameTests.cs
+++ b/tests/NameTests.cs
@@ -1,4 +1,4 @@
-﻿using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Models;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/NameTranslationTests.cs
+++ b/tests/NameTranslationTests.cs
@@ -1,4 +1,4 @@
-﻿using Rosette.Api.Endpoints;
+﻿using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/NameTranslationTests.cs
+++ b/tests/NameTranslationTests.cs
@@ -6,7 +6,7 @@ public class NameTranslationTests
 {
     [Fact]
     public void Constructor_SetsNameAndDefaults_WhenCalledWithName() {
-        NameTranslation n = new NameTranslation("foo");
+        NameTranslation n = new("foo");
         Assert.Equal("foo", n.Name);
         Assert.Equal("eng", n.TargetLanguage);
         Assert.Empty(n.EntityType);

--- a/tests/NameTranslationTests.cs
+++ b/tests/NameTranslationTests.cs
@@ -5,7 +5,7 @@ namespace Rosette.Api.Tests;
 public class NameTranslationTests
 {
     [Fact]
-    public void CheckBasicUsage() {
+    public void Constructor_SetsNameAndDefaults_WhenCalledWithName() {
         NameTranslation n = new NameTranslation("foo");
         Assert.Equal("foo", n.Name);
         Assert.Equal("eng", n.TargetLanguage);
@@ -18,7 +18,7 @@ public class NameTranslationTests
     }
 
     [Fact]
-    public void CheckAllUsage() {
+    public void FluentAPI_SetsAllProperties_WhenChaining() {
         NameTranslation n = new NameTranslation("foo")
             .SetEntityType("PERSON")
             .SetSourceLanguageOfOrigin("eng")

--- a/tests/NameTranslationTests.cs
+++ b/tests/NameTranslationTests.cs
@@ -1,41 +1,40 @@
 ﻿using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class NameTranslationTests
 {
-    public class NameTranslationTests
-    {
-        [Fact]
-        public void CheckBasicUsage() {
-            NameTranslation n = new NameTranslation("foo");
-            Assert.Equal("foo", n.Name);
-            Assert.Equal("eng", n.TargetLanguage);
-            Assert.Empty(n.EntityType);
-            Assert.Empty(n.SourceLanguageOfOrigin);
-            Assert.Empty(n.SourceLanguageOfUse);
-            Assert.Empty(n.SourceScript);
-            Assert.Empty(n.TargetScheme);
-            Assert.Empty(n.TargetScript);
-        }
-
-        [Fact]
-        public void CheckAllUsage() {
-            NameTranslation n = new NameTranslation("foo")
-                .SetEntityType("PERSON")
-                .SetSourceLanguageOfOrigin("eng")
-                .SetSourceLanguageOfUse("eng")
-                .SetSourceScript("zho")
-                .SetTargetLanguage("spa")
-                .SetTargetScheme("BGN")
-                .SetTargetScript("eng");
-            Assert.Equal("foo", n.Name);
-            Assert.Equal("spa", n.TargetLanguage);
-            Assert.Equal("PERSON", n.EntityType);
-            Assert.Equal("eng", n.SourceLanguageOfOrigin);
-            Assert.Equal("eng", n.SourceLanguageOfUse);
-            Assert.Equal("zho", n.SourceScript);
-            Assert.Equal("BGN", n.TargetScheme);
-            Assert.Equal("eng", n.TargetScript);
-        }
-
+    [Fact]
+    public void CheckBasicUsage() {
+        NameTranslation n = new NameTranslation("foo");
+        Assert.Equal("foo", n.Name);
+        Assert.Equal("eng", n.TargetLanguage);
+        Assert.Empty(n.EntityType);
+        Assert.Empty(n.SourceLanguageOfOrigin);
+        Assert.Empty(n.SourceLanguageOfUse);
+        Assert.Empty(n.SourceScript);
+        Assert.Empty(n.TargetScheme);
+        Assert.Empty(n.TargetScript);
     }
+
+    [Fact]
+    public void CheckAllUsage() {
+        NameTranslation n = new NameTranslation("foo")
+            .SetEntityType("PERSON")
+            .SetSourceLanguageOfOrigin("eng")
+            .SetSourceLanguageOfUse("eng")
+            .SetSourceScript("zho")
+            .SetTargetLanguage("spa")
+            .SetTargetScheme("BGN")
+            .SetTargetScript("eng");
+        Assert.Equal("foo", n.Name);
+        Assert.Equal("spa", n.TargetLanguage);
+        Assert.Equal("PERSON", n.EntityType);
+        Assert.Equal("eng", n.SourceLanguageOfOrigin);
+        Assert.Equal("eng", n.SourceLanguageOfUse);
+        Assert.Equal("zho", n.SourceScript);
+        Assert.Equal("BGN", n.TargetScheme);
+        Assert.Equal("eng", n.TargetScript);
+    }
+
 }

--- a/tests/RelationshipsTests.cs
+++ b/tests/RelationshipsTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests
 {

--- a/tests/RelationshipsTests.cs
+++ b/tests/RelationshipsTests.cs
@@ -8,7 +8,7 @@ namespace Rosette.Api.Tests
         public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
         {
             string text = "John works at Microsoft.";
-            Relationships r = new Relationships(text);
+            Relationships r = new(text);
 
             Assert.Equal("relationships", r.Endpoint);
             Assert.Equal(text, r.Content);

--- a/tests/RelationshipsTests.cs
+++ b/tests/RelationshipsTests.cs
@@ -5,31 +5,31 @@ namespace Rosette.Api.Tests
     public class RelationshipsTests
     {
         [Fact]
-        public void CheckBasicUsage()
+        public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
         {
             string text = "John works at Microsoft.";
             Relationships r = new Relationships(text);
-            
+
             Assert.Equal("relationships", r.Endpoint);
             Assert.Equal(text, r.Content);
         }
 
         [Fact]
-        public void CheckWithLanguage()
+        public void SetLanguage_SetsLanguageProperty_WhenCalled()
         {
             Relationships r = new Relationships("Sample text")
                 .SetLanguage("eng");
-            
+
             Assert.Equal("eng", r.Language);
         }
 
         [Fact]
-        public void CheckFluentAPI()
+        public void FluentAPI_AllowsMethodChaining_WhenSettingMultipleProperties()
         {
             Relationships r = new Relationships("Sample relationship text.")
                 .SetLanguage("eng")
                 .SetOption("accuracy", "high");
-            
+
             Assert.Equal("eng", r.Language);
             Assert.Equal("high", r.Options["accuracy"]);
         }

--- a/tests/ResponseTests.cs
+++ b/tests/ResponseTests.cs
@@ -7,7 +7,7 @@ namespace Rosette.Api.Tests;
 public class ResponseTests
 {
     [Fact]
-    public void CheckStatusOK() {
+    public void Constructor_SetsStatusCodeAndContent_WhenHttpResponseIsOK() {
         Dictionary<string, string> data = new Dictionary<string, string> {
             { "content", "Some sample content" },
             { "language", "eng" }

--- a/tests/ResponseTests.cs
+++ b/tests/ResponseTests.cs
@@ -2,27 +2,26 @@
 using System.Net;
 using System.Text.Json;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class ResponseTests
 {
-    public class ResponseTests
-    {
-        [Fact]
-        public void CheckStatusOK() {
-            Dictionary<string, string> data = new Dictionary<string, string> {
-                { "content", "Some sample content" },
-                { "language", "eng" }
-            };
-            string json = JsonSerializer.Serialize(data);
+    [Fact]
+    public void CheckStatusOK() {
+        Dictionary<string, string> data = new Dictionary<string, string> {
+            { "content", "Some sample content" },
+            { "language", "eng" }
+        };
+        string json = JsonSerializer.Serialize(data);
 
-            HttpResponseMessage msg = new HttpResponseMessage(HttpStatusCode.OK);
-            msg.Content = new StringContent(json);
-            msg.Headers.Add("Test-Header", "Test Header Content");
+        HttpResponseMessage msg = new HttpResponseMessage(HttpStatusCode.OK);
+        msg.Content = new StringContent(json);
+        msg.Headers.Add("Test-Header", "Test Header Content");
 
-            Response response = new Response(msg);
+        Response response = new Response(msg);
 
-            Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(json, response.ContentAsJson());
+        Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(json, response.ContentAsJson());
 
-        }
     }
 }

--- a/tests/ResponseTests.cs
+++ b/tests/ResponseTests.cs
@@ -1,4 +1,4 @@
-﻿using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Models;
 using System.Net;
 using System.Text.Json;
 

--- a/tests/ResponseTests.cs
+++ b/tests/ResponseTests.cs
@@ -8,17 +8,18 @@ public class ResponseTests
 {
     [Fact]
     public void Constructor_SetsStatusCodeAndContent_WhenHttpResponseIsOK() {
-        Dictionary<string, string> data = new Dictionary<string, string> {
+        Dictionary<string, string> data = new()
+        {
             { "content", "Some sample content" },
             { "language", "eng" }
         };
         string json = JsonSerializer.Serialize(data);
 
-        HttpResponseMessage msg = new HttpResponseMessage(HttpStatusCode.OK);
+        HttpResponseMessage msg = new(HttpStatusCode.OK);
         msg.Content = new StringContent(json);
         msg.Headers.Add("Test-Header", "Test Header Content");
 
-        Response response = new Response(msg);
+        Response response = new(msg);
 
         Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(json, response.ContentAsJson());

--- a/tests/SentencesTests.cs
+++ b/tests/SentencesTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/SentencesTests.cs
+++ b/tests/SentencesTests.cs
@@ -5,30 +5,30 @@ namespace Rosette.Api.Tests;
 public class SentencesTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         string text = "This is the first sentence. This is the second sentence.";
         Sentences s = new Sentences(text);
-        
+
         Assert.Equal("sentences", s.Endpoint);
         Assert.Equal(text, s.Content);
     }
 
     [Fact]
-    public void CheckWithLanguage()
+    public void SetLanguage_SetsLanguageProperty_WhenCalled()
     {
         Sentences s = new Sentences("Sample text.")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", s.Language);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingLanguage()
     {
         Sentences s = new Sentences("Text content.")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", s.Language);
     }
 }

--- a/tests/SentencesTests.cs
+++ b/tests/SentencesTests.cs
@@ -1,35 +1,34 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class SentencesTests
 {
-    public class SentencesTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            string text = "This is the first sentence. This is the second sentence.";
-            Sentences s = new Sentences(text);
-            
-            Assert.Equal("sentences", s.Endpoint);
-            Assert.Equal(text, s.Content);
-        }
+        string text = "This is the first sentence. This is the second sentence.";
+        Sentences s = new Sentences(text);
+        
+        Assert.Equal("sentences", s.Endpoint);
+        Assert.Equal(text, s.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguage()
-        {
-            Sentences s = new Sentences("Sample text.")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", s.Language);
-        }
+    [Fact]
+    public void CheckWithLanguage()
+    {
+        Sentences s = new Sentences("Sample text.")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", s.Language);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            Sentences s = new Sentences("Text content.")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", s.Language);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        Sentences s = new Sentences("Text content.")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", s.Language);
     }
 }

--- a/tests/SentencesTests.cs
+++ b/tests/SentencesTests.cs
@@ -8,7 +8,7 @@ public class SentencesTests
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         string text = "This is the first sentence. This is the second sentence.";
-        Sentences s = new Sentences(text);
+        Sentences s = new(text);
 
         Assert.Equal("sentences", s.Endpoint);
         Assert.Equal(text, s.Content);

--- a/tests/SentimentTests.cs
+++ b/tests/SentimentTests.cs
@@ -7,7 +7,7 @@ public class SentimentTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
-        Sentiment s = new Sentiment("This is a great product!");
+        Sentiment s = new("This is a great product!");
 
         Assert.Equal("sentiment", s.Endpoint);
         Assert.Equal("This is a great product!", s.Content);

--- a/tests/SentimentTests.cs
+++ b/tests/SentimentTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/SentimentTests.cs
+++ b/tests/SentimentTests.cs
@@ -1,46 +1,45 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class SentimentTests
 {
-    public class SentimentTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            Sentiment s = new Sentiment("This is a great product!");
-            
-            Assert.Equal("sentiment", s.Endpoint);
-            Assert.Equal("This is a great product!", s.Content);
-        }
+        Sentiment s = new Sentiment("This is a great product!");
+        
+        Assert.Equal("sentiment", s.Endpoint);
+        Assert.Equal("This is a great product!", s.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguage()
-        {
-            Sentiment s = new Sentiment("Sample text")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", s.Language);
-            Assert.Equal("Sample text", s.Content);
-        }
+    [Fact]
+    public void CheckWithLanguage()
+    {
+        Sentiment s = new Sentiment("Sample text")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", s.Language);
+        Assert.Equal("Sample text", s.Content);
+    }
 
-        [Fact]
-        public void CheckWithGenre()
-        {
-            Sentiment s = new Sentiment("Sample text")
-                .SetGenre("social-media");
-            
-            Assert.Equal("", s.Genre);
-        }
+    [Fact]
+    public void CheckWithGenre()
+    {
+        Sentiment s = new Sentiment("Sample text")
+            .SetGenre("social-media");
+        
+        Assert.Equal("", s.Genre);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            Sentiment s = new Sentiment("Great service!")
-                .SetLanguage("eng")
-                .SetOption("sentiment.threshold", 0.5);
-            
-            Assert.Equal("eng", s.Language);
-            Assert.Equal(0.5, s.Options["sentiment.threshold"]);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        Sentiment s = new Sentiment("Great service!")
+            .SetLanguage("eng")
+            .SetOption("sentiment.threshold", 0.5);
+        
+        Assert.Equal("eng", s.Language);
+        Assert.Equal(0.5, s.Options["sentiment.threshold"]);
     }
 }

--- a/tests/SentimentTests.cs
+++ b/tests/SentimentTests.cs
@@ -5,40 +5,40 @@ namespace Rosette.Api.Tests;
 public class SentimentTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         Sentiment s = new Sentiment("This is a great product!");
-        
+
         Assert.Equal("sentiment", s.Endpoint);
         Assert.Equal("This is a great product!", s.Content);
     }
 
     [Fact]
-    public void CheckWithLanguage()
+    public void SetLanguage_SetsLanguageProperty_WhenCalled()
     {
         Sentiment s = new Sentiment("Sample text")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", s.Language);
         Assert.Equal("Sample text", s.Content);
     }
 
     [Fact]
-    public void CheckWithGenre()
+    public void SetGenre_SetsGenreProperty_WhenCalled()
     {
         Sentiment s = new Sentiment("Sample text")
             .SetGenre("social-media");
-        
+
         Assert.Equal("", s.Genre);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingMultipleProperties()
     {
         Sentiment s = new Sentiment("Great service!")
             .SetLanguage("eng")
             .SetOption("sentiment.threshold", 0.5);
-        
+
         Assert.Equal("eng", s.Language);
         Assert.Equal(0.5, s.Options["sentiment.threshold"]);
     }

--- a/tests/SimilarTermsTests.cs
+++ b/tests/SimilarTermsTests.cs
@@ -7,7 +7,7 @@ public class SimilarTermsTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
-        SimilarTerms st = new SimilarTerms("happy");
+        SimilarTerms st = new("happy");
 
         Assert.Equal("semantics/similar", st.Endpoint);
         Assert.Equal("happy", st.Content);

--- a/tests/SimilarTermsTests.cs
+++ b/tests/SimilarTermsTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/SimilarTermsTests.cs
+++ b/tests/SimilarTermsTests.cs
@@ -1,37 +1,36 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class SimilarTermsTests
 {
-    public class SimilarTermsTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            SimilarTerms st = new SimilarTerms("happy");
-            
-            Assert.Equal("semantics/similar", st.Endpoint);
-            Assert.Equal("happy", st.Content);
-        }
+        SimilarTerms st = new SimilarTerms("happy");
+        
+        Assert.Equal("semantics/similar", st.Endpoint);
+        Assert.Equal("happy", st.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguage()
-        {
-            SimilarTerms st = new SimilarTerms("computer")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", st.Language);
-            Assert.Equal("computer", st.Content);
-        }
+    [Fact]
+    public void CheckWithLanguage()
+    {
+        SimilarTerms st = new SimilarTerms("computer")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", st.Language);
+        Assert.Equal("computer", st.Content);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            SimilarTerms st = new SimilarTerms("innovation")
-                .SetLanguage("eng")
-                .SetOption("count", 10);
-            
-            Assert.Equal("eng", st.Language);
-            Assert.Equal(10, st.Options["count"]);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        SimilarTerms st = new SimilarTerms("innovation")
+            .SetLanguage("eng")
+            .SetOption("count", 10);
+        
+        Assert.Equal("eng", st.Language);
+        Assert.Equal(10, st.Options["count"]);
     }
 }

--- a/tests/SimilarTermsTests.cs
+++ b/tests/SimilarTermsTests.cs
@@ -5,31 +5,31 @@ namespace Rosette.Api.Tests;
 public class SimilarTermsTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         SimilarTerms st = new SimilarTerms("happy");
-        
+
         Assert.Equal("semantics/similar", st.Endpoint);
         Assert.Equal("happy", st.Content);
     }
 
     [Fact]
-    public void CheckWithLanguage()
+    public void SetLanguage_SetsLanguageProperty_WhenCalled()
     {
         SimilarTerms st = new SimilarTerms("computer")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", st.Language);
         Assert.Equal("computer", st.Content);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingMultipleProperties()
     {
         SimilarTerms st = new SimilarTerms("innovation")
             .SetLanguage("eng")
             .SetOption("count", 10);
-        
+
         Assert.Equal("eng", st.Language);
         Assert.Equal(10, st.Options["count"]);
     }

--- a/tests/TokensTests.cs
+++ b/tests/TokensTests.cs
@@ -5,29 +5,29 @@ namespace Rosette.Api.Tests;
 public class TokensTests
 {
     [Fact]
-    public void CheckBasicUsage()
+    public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
         Tokens t = new Tokens("This is sample text");
-        
+
         Assert.Equal("tokens", t.Endpoint);
         Assert.Equal("This is sample text", t.Content);
     }
 
     [Fact]
-    public void CheckWithLanguage()
+    public void SetLanguage_SetsLanguageProperty_WhenCalled()
     {
         Tokens t = new Tokens("Sample text")
             .SetLanguage("eng");
-        
+
         Assert.Equal("eng", t.Language);
     }
 
     [Fact]
-    public void CheckFluentAPI()
+    public void FluentAPI_AllowsMethodChaining_WhenSettingLanguage()
     {
         Tokens t = new Tokens("Sample text")
             .SetLanguage("jpn");
-        
+
         Assert.Equal("jpn", t.Language);
     }
 }

--- a/tests/TokensTests.cs
+++ b/tests/TokensTests.cs
@@ -1,4 +1,4 @@
-using Rosette.Api.Endpoints;
+using Rosette.Api.Client.Endpoints;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/TokensTests.cs
+++ b/tests/TokensTests.cs
@@ -1,34 +1,33 @@
 using Rosette.Api.Endpoints;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class TokensTests
 {
-    public class TokensTests
+    [Fact]
+    public void CheckBasicUsage()
     {
-        [Fact]
-        public void CheckBasicUsage()
-        {
-            Tokens t = new Tokens("This is sample text");
-            
-            Assert.Equal("tokens", t.Endpoint);
-            Assert.Equal("This is sample text", t.Content);
-        }
+        Tokens t = new Tokens("This is sample text");
+        
+        Assert.Equal("tokens", t.Endpoint);
+        Assert.Equal("This is sample text", t.Content);
+    }
 
-        [Fact]
-        public void CheckWithLanguage()
-        {
-            Tokens t = new Tokens("Sample text")
-                .SetLanguage("eng");
-            
-            Assert.Equal("eng", t.Language);
-        }
+    [Fact]
+    public void CheckWithLanguage()
+    {
+        Tokens t = new Tokens("Sample text")
+            .SetLanguage("eng");
+        
+        Assert.Equal("eng", t.Language);
+    }
 
-        [Fact]
-        public void CheckFluentAPI()
-        {
-            Tokens t = new Tokens("Sample text")
-                .SetLanguage("jpn");
-            
-            Assert.Equal("jpn", t.Language);
-        }
+    [Fact]
+    public void CheckFluentAPI()
+    {
+        Tokens t = new Tokens("Sample text")
+            .SetLanguage("jpn");
+        
+        Assert.Equal("jpn", t.Language);
     }
 }

--- a/tests/TokensTests.cs
+++ b/tests/TokensTests.cs
@@ -7,7 +7,7 @@ public class TokensTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCalledWithText()
     {
-        Tokens t = new Tokens("This is sample text");
+        Tokens t = new("This is sample text");
 
         Assert.Equal("tokens", t.Endpoint);
         Assert.Equal("This is sample text", t.Content);

--- a/tests/ValidEndpointTests.cs
+++ b/tests/ValidEndpointTests.cs
@@ -1,5 +1,5 @@
-﻿using Rosette.Api.Endpoints;
-using Rosette.Api.Models;
+﻿using Rosette.Api.Client.Endpoints;
+using Rosette.Api.Client.Models;
 
 namespace Rosette.Api.Tests;
 

--- a/tests/ValidEndpointTests.cs
+++ b/tests/ValidEndpointTests.cs
@@ -11,14 +11,14 @@ public class ValidEndpointTests
     {
         var a = new UnfieldedAddressRecord { Address = "foo" };
 
-        AddressSimilarity asim = new AddressSimilarity(a,a);
+        AddressSimilarity asim = new(a,a);
         Assert.Equal("address-similarity", asim.Endpoint);
     }
 
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingCategories()
     {
-        Categories c = new Categories("foo");
+        Categories c = new("foo");
 
         Assert.Equal("categories", c.Endpoint);
         Assert.Equal("foo", c.Content);
@@ -27,7 +27,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingEntities()
     {
-        Entities e = new Entities("foo");
+        Entities e = new("foo");
         Assert.Equal("entities", e.Endpoint);
         Assert.Equal("foo", e.Content);
     }
@@ -35,7 +35,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingEvents()
     {
-        Events e = new Events("foo");
+        Events e = new("foo");
         Assert.Equal("events", e.Endpoint);
         Assert.Equal("foo", e.Content);
     }
@@ -43,14 +43,14 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpoint_WhenCreatingInfo()
     {
-        Info i = new Info();
+        Info i = new();
         Assert.Equal("info", i.Endpoint);
     }
 
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingLanguage()
     {
-        Language l = new Language("foo");
+        Language l = new("foo");
 
         Assert.Equal("language", l.Endpoint);
         Assert.Equal("foo", l.Content);
@@ -64,7 +64,7 @@ public class ValidEndpointTests
     [InlineData(MorphologyFeature.partsOfSpeech)]
     public void Constructor_SetsEndpointAndContent_WhenCreatingMorphologyWithFeature(MorphologyFeature feature)
     {
-        Morphology m = new Morphology("foo", feature);
+        Morphology m = new("foo", feature);
 
         Assert.Equal("morphology/" + m.FeatureAsString(feature), m.Endpoint);
         Assert.Equal("foo", m.Content);
@@ -77,7 +77,7 @@ public class ValidEndpointTests
             new Name("foo"),
             new Name("bar")
         ];
-        NameDeduplication nd = new NameDeduplication(names);
+        NameDeduplication nd = new(names);
 
         Assert.Equal("name-deduplication", nd.Endpoint);
     }
@@ -85,15 +85,15 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpoint_WhenCreatingNameSimilarity()
     {
-        Name rn = new Name("foo");
-        NameSimilarity ns = new NameSimilarity(rn, rn);
+        Name rn = new("foo");
+        NameSimilarity ns = new(rn, rn);
         Assert.Equal("name-similarity", ns.Endpoint);
     }
 
     [Fact]
     public void Constructor_SetsEndpoint_WhenCreatingNameTranslation()
     {
-        NameTranslation nt = new NameTranslation("foo");
+        NameTranslation nt = new("foo");
 
         Assert.Equal("name-translation", nt.Endpoint);
     }
@@ -101,7 +101,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpoint_WhenCreatingPing()
     {
-        Ping p = new Ping();
+        Ping p = new();
         Assert.Equal("ping", p.Endpoint);
     }
 
@@ -112,7 +112,7 @@ public class ValidEndpointTests
         var properties = new RecordSimilarityProperties();
         var records = new RecordSimilarityRecords();
 
-        RecordSimilarity rs = new RecordSimilarity(fields, properties, records);
+        RecordSimilarity rs = new(fields, properties, records);
 
         Assert.Equal("record-similarity", rs.Endpoint);
     }
@@ -120,7 +120,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingRelationships()
     {
-        Relationships r = new Relationships("foo");
+        Relationships r = new("foo");
 
         Assert.Equal("relationships", r.Endpoint);
         Assert.Equal("foo", r.Content);
@@ -129,7 +129,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingSemanticsVector()
     {
-        SemanticsVector s = new SemanticsVector("foo");
+        SemanticsVector s = new("foo");
         Assert.Equal("semantics/vector", s.Endpoint);
         Assert.Equal("foo", s.Content);
     }
@@ -137,7 +137,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingSentences()
     {
-        Sentences s = new Sentences("foo");
+        Sentences s = new("foo");
         Assert.Equal("sentences", s.Endpoint);
         Assert.Equal("foo", s.Content);
     }
@@ -145,7 +145,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingSentiment()
     {
-        Sentiment s = new Sentiment("foo");
+        Sentiment s = new("foo");
         Assert.Equal("sentiment", s.Endpoint);
         Assert.Equal("foo", s.Content);
     }
@@ -153,7 +153,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingSimilarTerms()
     {
-        SimilarTerms st = new SimilarTerms("foo");
+        SimilarTerms st = new("foo");
 
         Assert.Equal("semantics/similar", st.Endpoint);
         Assert.Equal("foo", st.Content);
@@ -162,7 +162,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingSyntaxDependencies()
     {
-        SyntaxDependencies s = new SyntaxDependencies("foo");
+        SyntaxDependencies s = new("foo");
 
         Assert.Equal("syntax/dependencies", s.Endpoint);
         Assert.Equal("foo", s.Content);
@@ -171,7 +171,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingTextEmbedding()
     {
-        TextEmbedding t = new TextEmbedding("foo");
+        TextEmbedding t = new("foo");
 
         Assert.Equal("text-embedding", t.Endpoint);
         Assert.Equal("foo", t.Content);
@@ -180,7 +180,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingTokens()
     {
-        Tokens t = new Tokens("foo");
+        Tokens t = new("foo");
 
         Assert.Equal("tokens", t.Endpoint);
         Assert.Equal("foo", t.Content);
@@ -189,7 +189,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingTopics()
     {
-        Topics t = new Topics("foo");
+        Topics t = new("foo");
 
         Assert.Equal("topics", t.Endpoint);
         Assert.Equal("foo", t.Content);
@@ -198,7 +198,7 @@ public class ValidEndpointTests
     [Fact]
     public void Constructor_SetsEndpointAndContent_WhenCreatingTransliteration()
     {
-        Transliteration t = new Transliteration("foo");
+        Transliteration t = new("foo");
 
         Assert.Equal("transliteration", t.Endpoint);
         Assert.Equal("foo", t.Content);

--- a/tests/ValidEndpointTests.cs
+++ b/tests/ValidEndpointTests.cs
@@ -1,207 +1,206 @@
 ﻿using Rosette.Api.Endpoints;
 using Rosette.Api.Models;
 
-namespace Rosette.Api.Tests
+namespace Rosette.Api.Tests;
+
+public class ValidEndpointTests
 {
-    public class ValidEndpointTests
+
+    [Fact]
+    public void AddressSimilarityEndpoint()
     {
+        var a = new UnfieldedAddressRecord { Address = "foo" };
 
-        [Fact]
-        public void AddressSimilarityEndpoint()
-        {
-            var a = new UnfieldedAddressRecord { Address = "foo" };
+        AddressSimilarity asim = new AddressSimilarity(a,a);
+        Assert.Equal("address-similarity", asim.Endpoint);
+    }
 
-            AddressSimilarity asim = new AddressSimilarity(a,a);
-            Assert.Equal("address-similarity", asim.Endpoint);
-        }
+    [Fact]
+    public void CategoriesEndpoint()
+    {
+        Categories c = new Categories("foo");
 
-        [Fact]
-        public void CategoriesEndpoint()
-        {
-            Categories c = new Categories("foo");
+        Assert.Equal("categories", c.Endpoint);
+        Assert.Equal("foo", c.Content);
+    }
 
-            Assert.Equal("categories", c.Endpoint);
-            Assert.Equal("foo", c.Content);
-        }
+    [Fact]
+    public void EntitiesEndpoint()
+    {
+        Entities e = new Entities("foo");
+        Assert.Equal("entities", e.Endpoint);
+        Assert.Equal("foo", e.Content);
+    }
 
-        [Fact]
-        public void EntitiesEndpoint()
-        {
-            Entities e = new Entities("foo");
-            Assert.Equal("entities", e.Endpoint);
-            Assert.Equal("foo", e.Content);
-        }
+    [Fact]
+    public void EventsEndpoint()
+    {
+        Events e = new Events("foo");
+        Assert.Equal("events", e.Endpoint);
+        Assert.Equal("foo", e.Content);
+    }
 
-        [Fact]
-        public void EventsEndpoint()
-        {
-            Events e = new Events("foo");
-            Assert.Equal("events", e.Endpoint);
-            Assert.Equal("foo", e.Content);
-        }
+    [Fact]
+    public void InfoEndpoint()
+    {
+        Info i = new Info();
+        Assert.Equal("info", i.Endpoint);
+    }
 
-        [Fact]
-        public void InfoEndpoint()
-        {
-            Info i = new Info();
-            Assert.Equal("info", i.Endpoint);
-        }
+    [Fact]
+    public void LanguageEndpoint()
+    {
+        Language l = new Language("foo");
 
-        [Fact]
-        public void LanguageEndpoint()
-        {
-            Language l = new Language("foo");
+        Assert.Equal("language", l.Endpoint);
+        Assert.Equal("foo", l.Content);
+    }
 
-            Assert.Equal("language", l.Endpoint);
-            Assert.Equal("foo", l.Content);
-        }
+    [Theory]
+    [InlineData(MorphologyFeature.complete)]
+    [InlineData(MorphologyFeature.compoundComponents)]
+    [InlineData(MorphologyFeature.hanReadings)]
+    [InlineData(MorphologyFeature.lemmas)]
+    [InlineData(MorphologyFeature.partsOfSpeech)]
+    public void MorphologyEndpoint(MorphologyFeature feature)
+    {
+        Morphology m = new Morphology("foo", feature);
 
-        [Theory]
-        [InlineData(MorphologyFeature.complete)]
-        [InlineData(MorphologyFeature.compoundComponents)]
-        [InlineData(MorphologyFeature.hanReadings)]
-        [InlineData(MorphologyFeature.lemmas)]
-        [InlineData(MorphologyFeature.partsOfSpeech)]
-        public void MorphologyEndpoint(MorphologyFeature feature)
-        {
-            Morphology m = new Morphology("foo", feature);
+        Assert.Equal("morphology/" + m.FeatureAsString(feature), m.Endpoint);
+        Assert.Equal("foo", m.Content);
+    }
 
-            Assert.Equal("morphology/" + m.FeatureAsString(feature), m.Endpoint);
-            Assert.Equal("foo", m.Content);
-        }
+    [Fact]
+    public void NameDeduplicationEndpoint()
+    {
+        List<Name> names = [
+            new Name("foo"),
+            new Name("bar")
+        ];
+        NameDeduplication nd = new NameDeduplication(names);
 
-        [Fact]
-        public void NameDeduplicationEndpoint()
-        {
-            List<Name> names = [
-                new Name("foo"),
-                new Name("bar")
-            ];
-            NameDeduplication nd = new NameDeduplication(names);
+        Assert.Equal("name-deduplication", nd.Endpoint);
+    }
 
-            Assert.Equal("name-deduplication", nd.Endpoint);
-        }
+    [Fact]
+    public void NameSimilarityEndpoint()
+    {
+        Name rn = new Name("foo");
+        NameSimilarity ns = new NameSimilarity(rn, rn);
+        Assert.Equal("name-similarity", ns.Endpoint);
+    }
 
-        [Fact]
-        public void NameSimilarityEndpoint()
-        {
-            Name rn = new Name("foo");
-            NameSimilarity ns = new NameSimilarity(rn, rn);
-            Assert.Equal("name-similarity", ns.Endpoint);
-        }
+    [Fact]
+    public void NameTranslationEndpoint()
+    {
+        NameTranslation nt = new NameTranslation("foo");
 
-        [Fact]
-        public void NameTranslationEndpoint()
-        {
-            NameTranslation nt = new NameTranslation("foo");
+        Assert.Equal("name-translation", nt.Endpoint);
+    }
 
-            Assert.Equal("name-translation", nt.Endpoint);
-        }
+    [Fact]
+    public void PingEndpoint()
+    {
+        Ping p = new Ping();
+        Assert.Equal("ping", p.Endpoint);
+    }
 
-        [Fact]
-        public void PingEndpoint()
-        {
-            Ping p = new Ping();
-            Assert.Equal("ping", p.Endpoint);
-        }
+    [Fact]
+    public void RecordSimilarityEndpoint()
+    {
+        var fields = new Dictionary<string, RecordSimilarityFieldInfo>();
+        var properties = new RecordSimilarityProperties();
+        var records = new RecordSimilarityRecords();
 
-        [Fact]
-        public void RecordSimilarityEndpoint()
-        {
-            var fields = new Dictionary<string, RecordSimilarityFieldInfo>();
-            var properties = new RecordSimilarityProperties();
-            var records = new RecordSimilarityRecords();
+        RecordSimilarity rs = new RecordSimilarity(fields, properties, records);
 
-            RecordSimilarity rs = new RecordSimilarity(fields, properties, records);
+        Assert.Equal("record-similarity", rs.Endpoint);
+    }
 
-            Assert.Equal("record-similarity", rs.Endpoint);
-        }
+    [Fact]
+    public void RelationshipsEndpoint()
+    {
+        Relationships r = new Relationships("foo");
 
-        [Fact]
-        public void RelationshipsEndpoint()
-        {
-            Relationships r = new Relationships("foo");
+        Assert.Equal("relationships", r.Endpoint);
+        Assert.Equal("foo", r.Content);
+    }
 
-            Assert.Equal("relationships", r.Endpoint);
-            Assert.Equal("foo", r.Content);
-        }
+    [Fact]
+    public void SemanticVectorsEndpoint()
+    {
+        SemanticsVector s = new SemanticsVector("foo");
+        Assert.Equal("semantics/vector", s.Endpoint);
+        Assert.Equal("foo", s.Content);
+    }
 
-        [Fact]
-        public void SemanticVectorsEndpoint()
-        {
-            SemanticsVector s = new SemanticsVector("foo");
-            Assert.Equal("semantics/vector", s.Endpoint);
-            Assert.Equal("foo", s.Content);
-        }
+    [Fact]
+    public void SentencesEndpoint()
+    {
+        Sentences s = new Sentences("foo");
+        Assert.Equal("sentences", s.Endpoint);
+        Assert.Equal("foo", s.Content);
+    }
 
-        [Fact]
-        public void SentencesEndpoint()
-        {
-            Sentences s = new Sentences("foo");
-            Assert.Equal("sentences", s.Endpoint);
-            Assert.Equal("foo", s.Content);
-        }
+    [Fact]
+    public void SentimentEndpoint()
+    {
+        Sentiment s = new Sentiment("foo");
+        Assert.Equal("sentiment", s.Endpoint);
+        Assert.Equal("foo", s.Content);
+    }
 
-        [Fact]
-        public void SentimentEndpoint()
-        {
-            Sentiment s = new Sentiment("foo");
-            Assert.Equal("sentiment", s.Endpoint);
-            Assert.Equal("foo", s.Content);
-        }
+    [Fact]
+    public void SimilarTermsEndpoint()
+    {
+        SimilarTerms st = new SimilarTerms("foo");
 
-        [Fact]
-        public void SimilarTermsEndpoint()
-        {
-            SimilarTerms st = new SimilarTerms("foo");
+        Assert.Equal("semantics/similar", st.Endpoint);
+        Assert.Equal("foo", st.Content);
+    }
 
-            Assert.Equal("semantics/similar", st.Endpoint);
-            Assert.Equal("foo", st.Content);
-        }
+    [Fact]
+    public void SyntaxDependenciesEndpoint()
+    {
+        SyntaxDependencies s = new SyntaxDependencies("foo");
 
-        [Fact]
-        public void SyntaxDependenciesEndpoint()
-        {
-            SyntaxDependencies s = new SyntaxDependencies("foo");
+        Assert.Equal("syntax/dependencies", s.Endpoint);
+        Assert.Equal("foo", s.Content);
+    }
 
-            Assert.Equal("syntax/dependencies", s.Endpoint);
-            Assert.Equal("foo", s.Content);
-        }
+    [Fact]
+    public void TextEmbeddingEndpoint()
+    {
+        TextEmbedding t = new TextEmbedding("foo");
 
-        [Fact]
-        public void TextEmbeddingEndpoint()
-        {
-            TextEmbedding t = new TextEmbedding("foo");
+        Assert.Equal("text-embedding", t.Endpoint);
+        Assert.Equal("foo", t.Content);
+    }
 
-            Assert.Equal("text-embedding", t.Endpoint);
-            Assert.Equal("foo", t.Content);
-        }
+    [Fact]
+    public void TokensEndpoint()
+    {
+        Tokens t = new Tokens("foo");
 
-        [Fact]
-        public void TokensEndpoint()
-        {
-            Tokens t = new Tokens("foo");
+        Assert.Equal("tokens", t.Endpoint);
+        Assert.Equal("foo", t.Content);
+    }
 
-            Assert.Equal("tokens", t.Endpoint);
-            Assert.Equal("foo", t.Content);
-        }
+    [Fact]
+    public void TopicsEndpoint()
+    {
+        Topics t = new Topics("foo");
 
-        [Fact]
-        public void TopicsEndpoint()
-        {
-            Topics t = new Topics("foo");
+        Assert.Equal("topics", t.Endpoint);
+        Assert.Equal("foo", t.Content);
+    }
 
-            Assert.Equal("topics", t.Endpoint);
-            Assert.Equal("foo", t.Content);
-        }
+    [Fact]
+    public void TransliterationEndpoint()
+    {
+        Transliteration t = new Transliteration("foo");
 
-        [Fact]
-        public void TransliterationEndpoint()
-        {
-            Transliteration t = new Transliteration("foo");
-
-            Assert.Equal("transliteration", t.Endpoint);
-            Assert.Equal("foo", t.Content);
-        }
+        Assert.Equal("transliteration", t.Endpoint);
+        Assert.Equal("foo", t.Content);
     }
 }

--- a/tests/ValidEndpointTests.cs
+++ b/tests/ValidEndpointTests.cs
@@ -7,7 +7,7 @@ public class ValidEndpointTests
 {
 
     [Fact]
-    public void AddressSimilarityEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingAddressSimilarity()
     {
         var a = new UnfieldedAddressRecord { Address = "foo" };
 
@@ -16,7 +16,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void CategoriesEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingCategories()
     {
         Categories c = new Categories("foo");
 
@@ -25,7 +25,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void EntitiesEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingEntities()
     {
         Entities e = new Entities("foo");
         Assert.Equal("entities", e.Endpoint);
@@ -33,7 +33,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void EventsEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingEvents()
     {
         Events e = new Events("foo");
         Assert.Equal("events", e.Endpoint);
@@ -41,14 +41,14 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void InfoEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingInfo()
     {
         Info i = new Info();
         Assert.Equal("info", i.Endpoint);
     }
 
     [Fact]
-    public void LanguageEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingLanguage()
     {
         Language l = new Language("foo");
 
@@ -62,7 +62,7 @@ public class ValidEndpointTests
     [InlineData(MorphologyFeature.hanReadings)]
     [InlineData(MorphologyFeature.lemmas)]
     [InlineData(MorphologyFeature.partsOfSpeech)]
-    public void MorphologyEndpoint(MorphologyFeature feature)
+    public void Constructor_SetsEndpointAndContent_WhenCreatingMorphologyWithFeature(MorphologyFeature feature)
     {
         Morphology m = new Morphology("foo", feature);
 
@@ -71,7 +71,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void NameDeduplicationEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingNameDeduplication()
     {
         List<Name> names = [
             new Name("foo"),
@@ -83,7 +83,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void NameSimilarityEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingNameSimilarity()
     {
         Name rn = new Name("foo");
         NameSimilarity ns = new NameSimilarity(rn, rn);
@@ -91,7 +91,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void NameTranslationEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingNameTranslation()
     {
         NameTranslation nt = new NameTranslation("foo");
 
@@ -99,14 +99,14 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void PingEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingPing()
     {
         Ping p = new Ping();
         Assert.Equal("ping", p.Endpoint);
     }
 
     [Fact]
-    public void RecordSimilarityEndpoint()
+    public void Constructor_SetsEndpoint_WhenCreatingRecordSimilarity()
     {
         var fields = new Dictionary<string, RecordSimilarityFieldInfo>();
         var properties = new RecordSimilarityProperties();
@@ -118,7 +118,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void RelationshipsEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingRelationships()
     {
         Relationships r = new Relationships("foo");
 
@@ -127,7 +127,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void SemanticVectorsEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingSemanticsVector()
     {
         SemanticsVector s = new SemanticsVector("foo");
         Assert.Equal("semantics/vector", s.Endpoint);
@@ -135,7 +135,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void SentencesEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingSentences()
     {
         Sentences s = new Sentences("foo");
         Assert.Equal("sentences", s.Endpoint);
@@ -143,7 +143,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void SentimentEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingSentiment()
     {
         Sentiment s = new Sentiment("foo");
         Assert.Equal("sentiment", s.Endpoint);
@@ -151,7 +151,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void SimilarTermsEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingSimilarTerms()
     {
         SimilarTerms st = new SimilarTerms("foo");
 
@@ -160,7 +160,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void SyntaxDependenciesEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingSyntaxDependencies()
     {
         SyntaxDependencies s = new SyntaxDependencies("foo");
 
@@ -169,7 +169,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void TextEmbeddingEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingTextEmbedding()
     {
         TextEmbedding t = new TextEmbedding("foo");
 
@@ -178,7 +178,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void TokensEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingTokens()
     {
         Tokens t = new Tokens("foo");
 
@@ -187,7 +187,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void TopicsEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingTopics()
     {
         Topics t = new Topics("foo");
 
@@ -196,7 +196,7 @@ public class ValidEndpointTests
     }
 
     [Fact]
-    public void TransliterationEndpoint()
+    public void Constructor_SetsEndpointAndContent_WhenCreatingTransliteration()
     {
         Transliteration t = new Transliteration("foo");
 


### PR DESCRIPTION
✅ Added async/await support across the API
✅ Significantly expanded unit test coverage
✅ Namespace reorganization to Client and Examples
✅ Updated all references in examples and tests
✅ Modernized code syntax and conventions